### PR TITLE
Add API to Cloud.gov

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,7 @@
+# ignore everything
+.
+
+# except these
+!dist
+!package.json
+!package-lock.json

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -3,6 +3,6 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+  await app.listen(process.env.PORT || 3000);
 }
 bootstrap();

--- a/deploy-cloudgov.sh
+++ b/deploy-cloudgov.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+#/ Usage: bash create-services.sh
+#/ Description: This script creates the services (if necessary) to deploy to cloud.gov.
+#/ Then it runs any deploy scripts.
+#/ Examples:    
+#/ Options:     
+#/   --help: Display this help message
+usage() { grep '^#/' "$0" | cut -c4- ; exit 0 ; }
+expr "$*" : ".*--help" > /dev/null && usage
+
+echoerr() { printf "%s\n" "$*" >&2 ; }
+info()    { echoerr "[INFO]    $*" ; }
+warning() { echoerr "[WARNING] $*" ; }
+error()   { echoerr "[ERROR]   $*" ; }
+fatal()   { echoerr "[FATAL]   $*" ; exit 1 ; }
+
+cleanup() {
+  # Remove temporary files
+  # Restart services
+  info "... cleaned up"
+}
+
+# function to check if a service exists
+service_exists()
+{
+  info "checking if ${1} exists..."
+  cf service "$1" >/dev/null 2>&1
+}
+
+service_status()
+{
+  cf service "$1" | awk '/status:/ {print $2, $3}'
+}
+
+already_exists()
+{
+  info "${1} already exists..."
+}
+
+wait_until_created()
+{
+  info "waiting until ${1} is created..."
+
+  CREATED_STATUS=$(service_status "$1")
+  while [ "$CREATED_STATUS" != "create succeeded" ]
+  do
+    sleep 15
+    info "waiting for ${1} to be created..."
+    CREATED_STATUS=$(service_status "$1")
+  done
+}
+
+# Service Names 
+SCANNER_POSTGRES_NAME="scanner-postgres"
+SCANNER_POSTGRES_PLAN="micro-psql"
+SCANNER_MESSAGE_QUEUE_NAME="scanner-message-queue"
+SCANNER_MESSAGE_QUEUE_PLAN="standard"
+
+
+if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
+  trap cleanup EXIT
+  # Script goes here
+  info "starting deploy-cloudgov.sh script ..."
+
+  info "creating services if necessary..."
+
+  if service_exists "$SCANNER_POSTGRES_NAME" ; then
+    already_exists "$SCANNER_POSTGRES_NAME"
+  else 
+    cf create-service aws-rds $SCANNER_POSTGRES_PLAN $SCANNER_POSTGRES_NAME
+  fi
+
+  if service_exists "$SCANNER_MESSAGE_QUEUE_NAME" ; then
+    already_exists "$SCANNER_MESSAGE_QUEUE_NAME"
+  else
+    cf create-service redis32 $SCANNER_MESSAGE_QUEUE_PLAN $SCANNER_MESSAGE_QUEUE_NAME
+  fi
+
+  wait_until_created $SCANNER_POSTGRES_NAME
+  wait_until_created $SCANNER_MESSAGE_QUEUE_NAME
+  
+fi

--- a/libs/database/src/config/db.config.ts
+++ b/libs/database/src/config/db.config.ts
@@ -1,0 +1,26 @@
+/**
+ * dbconfig returns the appropriate database credentials for the environment.
+ */
+export default () => {
+  if (process.env.VCAP_SERVICES) {
+    console.log('found VCAP_SERVICES');
+    const vcap = JSON.parse(process.env.VCAP_SERVICES);
+    const rds = vcap['aws-rds'][0];
+    return {
+      database: {
+        url: rds.credentials.uri,
+      },
+    };
+  } else {
+    console.log('using development credentials.');
+    const pgUser = process.env.POSTGRES_USER;
+    const pgPassword = process.env.POSTGRES_PASSWORD;
+    const dbHost = process.env.DATABASE_HOST;
+    const dbPort = process.env.DATABASE_PORT;
+    return {
+      database: {
+        url: `postgresql://${pgUser}:${pgPassword}@${dbHost}:${dbPort}`,
+      },
+    };
+  }
+};

--- a/libs/database/src/config/db.config.ts
+++ b/libs/database/src/config/db.config.ts
@@ -3,7 +3,6 @@
  */
 export default () => {
   if (process.env.VCAP_SERVICES) {
-    console.log('found VCAP_SERVICES');
     const vcap = JSON.parse(process.env.VCAP_SERVICES);
     const rds = vcap['aws-rds'][0];
     return {
@@ -12,7 +11,6 @@ export default () => {
       },
     };
   } else {
-    console.log('using development credentials.');
     const pgUser = process.env.POSTGRES_USER;
     const pgPassword = process.env.POSTGRES_PASSWORD;
     const dbHost = process.env.DATABASE_HOST;

--- a/libs/database/src/database.module.ts
+++ b/libs/database/src/database.module.ts
@@ -5,16 +5,18 @@ import { CoreResult } from './core-results/core-result.entity';
 import { CoreResultModule } from './core-results/core-result.module';
 import { Website } from './websites/website.entity';
 import { WebsiteModule } from './websites/website.module';
+import dbconfig from './config/db.config';
 
 const ScannerDatabase = TypeOrmModule.forRootAsync({
-  imports: [ConfigModule],
+  imports: [
+    ConfigModule.forRoot({
+      load: [dbconfig],
+    }),
+  ],
   useFactory: (configService: ConfigService) => {
     return {
       type: 'postgres',
-      host: configService.get('DATABASE_HOST'),
-      port: +configService.get<number>('DATABASE_PORT'),
-      username: configService.get('POSTGRES_USER'),
-      password: configService.get('POSTGRES_PASSWORD'),
+      url: configService.get<string>('database.url'),
       entities: [Website, CoreResult],
       synchronize: true,
     };

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,11 @@
+---
+applications:
+- name: site-scanner-api
+  disk_quota: 4096M
+  timeout: 10 # seconds
+  services:
+    - scanner-postgres
+  memory: 500M
+  instances: 1
+  random-route: true
+  command: node dist/apps/api/main

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "prebuild": "rimraf dist",
+    "rmdist": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"apps/**/*.ts\" \"libs/**/*.ts\"",
     "start": "nest start",


### PR DESCRIPTION
**Why**: This adds the site-scanning-api to Cloud.gov.

**How**: Add a deploy-cloudgov.sh script which (currently) only creates the
services necessary. Note that there is some logic in the script that
checks if Postgres is created, but I just read that this logic is
actually incorrect! I'll update in the next PR.

Add a manifest.yml to specify the api name and how
to run it -- this also binds the postgres RDS instance to the
application.

Lastly, update the database configuration so that we pull in the
credentials using the ConfigService.

**tags**: postgres, cloud.gov, config, api