### PR TITLE
Add logger

### DIFF
--- a/apps/producer/src/producer.module.ts
+++ b/apps/producer/src/producer.module.ts
@@ -4,6 +4,7 @@ import { MessageQueueModule } from '@app/message-queue';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
+import { LoggerModule, LoggerService } from 'libs/logger/src';
 import { ProducerService } from './producer/producer.service';
 import { TaskService } from './task/task.service';
 
@@ -13,7 +14,8 @@ import { TaskService } from './task/task.service';
     MessageQueueModule,
     ConfigModule.forRoot(),
     ScheduleModule.forRoot(),
+    LoggerModule,
   ],
-  providers: [ProducerService, TaskService, WebsiteService],
+  providers: [ProducerService, TaskService, WebsiteService, LoggerService],
 })
 export class ProducerModule {}

--- a/apps/producer/src/task/task.service.spec.ts
+++ b/apps/producer/src/task/task.service.spec.ts
@@ -1,5 +1,6 @@
 import { Website } from '@app/database/websites/website.entity';
 import { WebsiteService } from '@app/database/websites/websites.service';
+import { LoggerService } from '@app/logger';
 import { Test, TestingModule } from '@nestjs/testing';
 import { mock, mockReset, MockProxy } from 'jest-mock-extended';
 import { ProducerService } from '../producer/producer.service';
@@ -9,10 +10,12 @@ describe('TaskService', () => {
   let service: TaskService;
   let producerMock: MockProxy<ProducerService>;
   let websiteServiceMock: MockProxy<WebsiteService>;
+  let loggerMock: MockProxy<LoggerService>;
 
   beforeEach(async () => {
     producerMock = mock<ProducerService>();
     websiteServiceMock = mock<WebsiteService>();
+    loggerMock = mock<LoggerService>();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TaskService,
@@ -23,6 +26,10 @@ describe('TaskService', () => {
         {
           provide: WebsiteService,
           useValue: websiteServiceMock,
+        },
+        {
+          provide: LoggerService,
+          useValue: loggerMock,
         },
       ],
     }).compile();

--- a/apps/producer/src/task/task.service.ts
+++ b/apps/producer/src/task/task.service.ts
@@ -1,17 +1,18 @@
 import { WebsiteService } from '@app/database/websites/websites.service';
-import { Injectable, Logger } from '@nestjs/common';
+import { LoggerService } from '@app/logger';
+import { Injectable } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { CoreInputDto } from 'dtos/scanners/core.input.dto';
 import { ProducerService } from '../producer/producer.service';
 
 @Injectable()
 export class TaskService {
-  private readonly logger: Logger;
   constructor(
     private producerService: ProducerService,
     private websiteService: WebsiteService,
+    private logger: LoggerService,
   ) {
-    this.logger = new Logger(TaskService.name);
+    this.logger.setContext(TaskService.name);
   }
 
   @Cron('46 * * * * *')
@@ -29,7 +30,7 @@ export class TaskService {
         this.producerService.addCoreJob(coreInput);
       });
     } catch (error) {
-      this.logger.error(error);
+      this.logger.error(`error in ${this.coreScanProducer.name}`, error);
     }
   }
 }

--- a/apps/scanner/src/scan-engine/scan-engine.consumer.spec.ts
+++ b/apps/scanner/src/scan-engine/scan-engine.consumer.spec.ts
@@ -8,6 +8,7 @@ import { ScanEngineConsumer } from './scan-engine.consumer';
 import { Job } from 'bull';
 import { CoreResultService } from '@app/database/core-results/core-result.service';
 import { CreateCoreResultDto } from '@app/database/core-results/dto/create-core-result.dto';
+import { LoggerService } from '@app/logger';
 
 describe('ScanEngineController', () => {
   let consumer: ScanEngineConsumer;
@@ -15,11 +16,13 @@ describe('ScanEngineController', () => {
   let mockCoreScanner: MockProxy<Scanner<CoreInputDto, CoreOutputDto>>;
   let mockCoreResultService: MockProxy<CoreResultService>;
   let mockJob: MockProxy<Job<CoreInputDto>>;
+  let mockLogger: MockProxy<LoggerService>;
 
   beforeEach(async () => {
     mockCoreScanner = mock<Scanner<CoreInputDto, CoreOutputDto>>();
     mockCoreResultService = mock<CoreResultService>();
     mockJob = mock<Job<CoreInputDto>>();
+    mockLogger = mock<LoggerService>();
     module = await Test.createTestingModule({
       providers: [
         ScanEngineConsumer,
@@ -30,6 +33,10 @@ describe('ScanEngineController', () => {
         {
           provide: CoreResultService,
           useValue: mockCoreResultService,
+        },
+        {
+          provide: LoggerService,
+          useValue: mockLogger,
         },
       ],
     }).compile();

--- a/apps/scanner/src/scan-engine/scan-engine.module.ts
+++ b/apps/scanner/src/scan-engine/scan-engine.module.ts
@@ -1,5 +1,6 @@
 import { DatabaseModule } from '@app/database';
 import { CoreResultService } from '@app/database/core-results/core-result.service';
+import { LoggerModule, LoggerService } from '@app/logger';
 import { MessageQueueModule } from '@app/message-queue';
 import { Module } from '@nestjs/common';
 import { CoreScanner } from '../scanners/core/core.scanner';
@@ -7,7 +8,12 @@ import { ScannersModule } from '../scanners/scanners.module';
 import { ScanEngineConsumer } from './scan-engine.consumer';
 
 @Module({
-  imports: [ScannersModule, MessageQueueModule, DatabaseModule],
-  providers: [CoreScanner, ScanEngineConsumer, CoreResultService],
+  imports: [ScannersModule, MessageQueueModule, DatabaseModule, LoggerModule],
+  providers: [
+    CoreScanner,
+    ScanEngineConsumer,
+    CoreResultService,
+    LoggerService,
+  ],
 })
 export class ScanEngineModule {}

--- a/libs/logger/src/index.ts
+++ b/libs/logger/src/index.ts
@@ -1,0 +1,2 @@
+export * from './logger.module';
+export * from './logger.service';

--- a/libs/logger/src/logger.module.ts
+++ b/libs/logger/src/logger.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { LoggerService } from './logger.service';
+
+@Module({
+  providers: [LoggerService],
+  exports: [LoggerService],
+})
+export class LoggerModule {}

--- a/libs/logger/src/logger.service.spec.ts
+++ b/libs/logger/src/logger.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LoggerService } from './logger.service';
+
+describe('LoggerService', () => {
+  let service: LoggerService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LoggerService],
+    }).compile();
+
+    service = module.get<LoggerService>(LoggerService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/libs/logger/src/logger.service.ts
+++ b/libs/logger/src/logger.service.ts
@@ -1,0 +1,9 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+@Injectable()
+export class LoggerService extends Logger {
+  error(message: string, trace: string) {
+    // add error reporting hook here
+    super.error(message, trace);
+  }
+}

--- a/libs/logger/tsconfig.lib.json
+++ b/libs/logger/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "../../dist/libs/logger"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -52,6 +52,15 @@
       "compilerOptions": {
         "tsConfigPath": "libs/database/tsconfig.lib.json"
       }
+    },
+    "logger": {
+      "type": "library",
+      "root": "libs/logger",
+      "entryFile": "index",
+      "sourceRoot": "libs/logger/src",
+      "compilerOptions": {
+        "tsConfigPath": "libs/logger/tsconfig.lib.json"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,9 @@
       "@app/message-queue/(.*)": "<rootDir>/libs/message-queue/src/$1",
       "@app/message-queue": "<rootDir>/libs/message-queue/src",
       "@app/database/(.*)": "<rootDir>/libs/database/src/$1",
-      "@app/database": "<rootDir>/libs/database/src"
+      "@app/database": "<rootDir>/libs/database/src",
+      "@app/logger/(.*)": "<rootDir>/libs/logger/src/$1",
+      "@app/logger": "<rootDir>/libs/logger/src"
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,12 @@
       ],
       "@app/database/*": [
         "libs/database/src/*"
+      ],
+      "@app/logger": [
+        "libs/logger/src"
+      ],
+      "@app/logger/*": [
+        "libs/logger/src/*"
       ]
     }
   }


### PR DESCRIPTION
Why: Add a custom logger to the application. 

How: I am creating a `LoggerModule` in the `libs` directory. This way we can use the same logger in the different applications. 

Tags: logging, library, libs, custom