### PR TITLE
Add basic fields to scanner

### DIFF
--- a/apps/scan-engine/src/scan-engine.consumer.spec.ts
+++ b/apps/scan-engine/src/scan-engine.consumer.spec.ts
@@ -63,6 +63,9 @@ describe('ScanEngineConsumer', () => {
     const coreOutputDto: CoreOutputDto = {
       websiteId: input.websiteId,
       finalUrl: 'https://18f.gsa.gov',
+      finalUrlIsLive: true,
+      finalUrlBaseDomain: 'gsa.gov',
+      targetUrlRedirects: true,
     };
 
     const createCoreResultDto: CreateCoreResultDto = {

--- a/apps/scan-engine/src/scan-engine.consumer.spec.ts
+++ b/apps/scan-engine/src/scan-engine.consumer.spec.ts
@@ -71,6 +71,9 @@ describe('ScanEngineConsumer', () => {
     const createCoreResultDto: CreateCoreResultDto = {
       websiteId: coreOutputDto.websiteId,
       finalUrl: coreOutputDto.finalUrl,
+      finalUrlIsLive: coreOutputDto.finalUrlIsLive,
+      finalUrlBaseDomain: coreOutputDto.finalUrlBaseDomain,
+      targetUrlRedirects: coreOutputDto.targetUrlRedirects,
     };
 
     mockJob.data = input;

--- a/apps/scan-engine/src/scan-engine.consumer.ts
+++ b/apps/scan-engine/src/scan-engine.consumer.ts
@@ -44,6 +44,9 @@ export class ScanEngineConsumer {
       await this.coreResultService.create({
         websiteId: job.data.websiteId,
         finalUrl: result.finalUrl,
+        finalUrlIsLive: result.finalUrlIsLive,
+        finalUrlBaseDomain: result.finalUrlBaseDomain,
+        targetUrlRedirects: result.targetUrlRedirects,
       });
       this.logger.debug(`wrote result for ${job.data.url}`);
       await job.moveToCompleted();

--- a/common/dtos/scanners/core.output.dto.ts
+++ b/common/dtos/scanners/core.output.dto.ts
@@ -1,4 +1,7 @@
 export class CoreOutputDto {
   websiteId: number;
   finalUrl: string;
+  finalUrlIsLive: boolean;
+  finalUrlBaseDomain: string;
+  targetUrlRedirects: boolean;
 }

--- a/libs/core-scanner/src/core-scanner.module.ts
+++ b/libs/core-scanner/src/core-scanner.module.ts
@@ -1,9 +1,10 @@
 import { BrowserModule, BrowserService } from '@app/browser';
+import { LoggerModule } from '@app/logger';
 import { Module } from '@nestjs/common';
 import { CoreScannerService } from './core-scanner.service';
 
 @Module({
-  imports: [BrowserModule],
+  imports: [BrowserModule, LoggerModule],
   providers: [CoreScannerService, BrowserService],
   exports: [CoreScannerService, BrowserModule],
 })

--- a/libs/core-scanner/src/core-scanner.service.spec.ts
+++ b/libs/core-scanner/src/core-scanner.service.spec.ts
@@ -1,4 +1,5 @@
 import { BROWSER_TOKEN } from '@app/browser';
+import { LoggerService } from '@app/logger';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CoreInputDto } from 'common/dtos/scanners/core.input.dto';
 import { mock, MockProxy } from 'jest-mock-extended';
@@ -10,17 +11,23 @@ describe('CoreScannerService', () => {
   let mockBrowser: MockProxy<Browser>;
   let mockPage: MockProxy<Page>;
   let mockResponse: MockProxy<Response>;
+  let mockLogger: MockProxy<LoggerService>;
 
   beforeEach(async () => {
     mockBrowser = mock<Browser>();
     mockPage = mock<Page>();
     mockResponse = mock<Response>();
+    mockLogger = mock<LoggerService>();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CoreScannerService,
         {
           provide: BROWSER_TOKEN,
           useValue: mockBrowser,
+        },
+        {
+          provide: LoggerService,
+          useValue: mockLogger,
         },
       ],
     }).compile();

--- a/libs/core-scanner/src/core-scanner.service.spec.ts
+++ b/libs/core-scanner/src/core-scanner.service.spec.ts
@@ -3,7 +3,7 @@ import { LoggerService } from '@app/logger';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CoreInputDto } from 'common/dtos/scanners/core.input.dto';
 import { mock, MockProxy } from 'jest-mock-extended';
-import { Browser, Page, Response } from 'puppeteer';
+import { Browser, Page, Response, Request } from 'puppeteer';
 import { CoreScannerService } from './core-scanner.service';
 
 describe('CoreScannerService', () => {
@@ -12,12 +12,17 @@ describe('CoreScannerService', () => {
   let mockPage: MockProxy<Page>;
   let mockResponse: MockProxy<Response>;
   let mockLogger: MockProxy<LoggerService>;
+  let mockRequest: MockProxy<Request>;
+  let redirectRequest: MockProxy<Request>;
 
   beforeEach(async () => {
     mockBrowser = mock<Browser>();
     mockPage = mock<Page>();
     mockResponse = mock<Response>();
     mockLogger = mock<LoggerService>();
+    mockRequest = mock<Request>();
+    redirectRequest = mock<Request>();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CoreScannerService,
@@ -45,6 +50,11 @@ describe('CoreScannerService', () => {
       url: 'https://18f.gov',
     };
     const finalUrl = 'https://18f.gsa.gov';
+
+    redirectRequest.url.calledWith().mockReturnValue('https://18f.gov');
+    mockRequest.redirectChain.calledWith().mockReturnValue([redirectRequest]);
+    mockResponse.request.calledWith().mockReturnValue(mockRequest);
+
     mockPage.goto.calledWith('https://18f.gov').mockResolvedValue(mockResponse);
     mockPage.url.calledWith().mockReturnValue(finalUrl);
     mockBrowser.newPage.calledWith().mockResolvedValue(mockPage);

--- a/libs/core-scanner/src/core-scanner.service.ts
+++ b/libs/core-scanner/src/core-scanner.service.ts
@@ -1,27 +1,60 @@
 import { BROWSER_TOKEN } from '@app/browser';
+import { LoggerService } from '@app/logger';
 import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { CoreInputDto } from 'common/dtos/scanners/core.input.dto';
 import { CoreOutputDto } from 'common/dtos/scanners/core.output.dto';
 import { Scanner } from 'common/interfaces/scanner.interface';
-import { Browser } from 'puppeteer';
+import { join, split, takeRight } from 'lodash';
+import { Browser, Page, Response } from 'puppeteer';
+import { URL } from 'url';
 
 @Injectable()
 export class CoreScannerService
   implements Scanner<CoreInputDto, CoreOutputDto>, OnModuleDestroy {
-  constructor(@Inject(BROWSER_TOKEN) private browser: Browser) {}
+  constructor(
+    @Inject(BROWSER_TOKEN) private browser: Browser,
+    private logger: LoggerService,
+  ) {}
 
   async scan(input: CoreInputDto) {
     const page = await this.browser.newPage();
-    await page.goto(input.url);
 
-    const finalUrl = page.url();
+    this.logger.debug(`loading ${input.url}`);
+    const response = await page.goto(input.url);
+    const redirects = response.request().redirectChain();
 
+    redirects.forEach(req => {
+      this.logger.debug(req.url());
+    });
+
+    const finalUrl = this.getFinalUrl(page);
     const result: CoreOutputDto = {
       websiteId: input.websiteId,
+      targetUrlRedirects: redirects.length > 0,
       finalUrl: finalUrl,
+      finalUrlIsLive: this.isLive(response),
+      finalUrlBaseDomain: this.getBaseDomain(finalUrl),
     };
 
+    this.logger.debug(`result for ${input.url}: ${JSON.stringify(result)}`);
     return result;
+  }
+
+  // 18f.gsa.gov -> gsa.gov
+  private getBaseDomain(url: string) {
+    const parsedUrl = new URL(url);
+    const baseDomain = takeRight(split(parsedUrl.hostname), 2);
+    return join(baseDomain, '.');
+  }
+
+  private getFinalUrl(page: Page) {
+    const finalUrl = page.url();
+    return finalUrl;
+  }
+
+  private isLive(res: Response) {
+    const isLive = res.status() / 100 == 2; // 2xx family
+    return isLive;
   }
 
   async onModuleDestroy() {

--- a/libs/database/src/core-results/core-result.entity.ts
+++ b/libs/database/src/core-results/core-result.entity.ts
@@ -22,9 +22,18 @@ export class CoreResult {
   @Column()
   finalUrl: string;
 
+  @Column()
+  finalUrlIsLive: boolean;
+
+  @Column()
+  finalUrlBaseDomain: string;
+
+  @Column()
+  targetUrlRedirects: boolean;
+
   @ManyToOne(
     () => Website,
     website => website.id,
   )
-  websiteId: number;
+  website: number;
 }

--- a/libs/database/src/core-results/core-result.service.spec.ts
+++ b/libs/database/src/core-results/core-result.service.spec.ts
@@ -35,7 +35,7 @@ describe('CoreResultService', () => {
 
   it('should return all CoreResults', async () => {
     const coreResult = new CoreResult();
-    coreResult.websiteId = 1;
+    coreResult.website = 1;
     coreResult.finalUrl = 'https://18f.gsa.gov';
 
     const expected = [coreResult];
@@ -60,11 +60,17 @@ describe('CoreResultService', () => {
     const coreResultDto: CreateCoreResultDto = {
       websiteId: 1,
       finalUrl: 'https://18f.gsa.gov',
+      finalUrlIsLive: true,
+      finalUrlBaseDomain: 'gsa.gov',
+      targetUrlRedirects: true,
     };
 
     const coreResult = new CoreResult();
     coreResult.finalUrl = coreResultDto.finalUrl;
-    coreResult.websiteId = coreResultDto.websiteId;
+    coreResult.website = coreResultDto.websiteId;
+    coreResult.finalUrlBaseDomain = coreResultDto.finalUrlBaseDomain;
+    coreResult.finalUrlIsLive = coreResultDto.finalUrlIsLive;
+    coreResult.targetUrlRedirects = coreResultDto.targetUrlRedirects;
 
     await service.create(coreResultDto);
     expect(mockRepository.save).toHaveBeenCalledWith(coreResult);

--- a/libs/database/src/core-results/core-result.service.ts
+++ b/libs/database/src/core-results/core-result.service.ts
@@ -22,7 +22,7 @@ export class CoreResultService {
 
   async findResultsWithWebsite() {
     const result = await this.coreResult.find({
-      relations: ['websiteId'],
+      relations: ['website'],
     });
 
     return result;
@@ -30,8 +30,11 @@ export class CoreResultService {
 
   async create(createCoreResultDto: CreateCoreResultDto) {
     const coreResult = new CoreResult();
-    coreResult.websiteId = createCoreResultDto.websiteId;
+    coreResult.website = createCoreResultDto.websiteId;
     coreResult.finalUrl = createCoreResultDto.finalUrl;
+    coreResult.finalUrlIsLive = createCoreResultDto.finalUrlIsLive;
+    coreResult.finalUrlBaseDomain = createCoreResultDto.finalUrlBaseDomain;
+    coreResult.targetUrlRedirects = createCoreResultDto.targetUrlRedirects;
     await this.coreResult.save(coreResult);
   }
 }

--- a/libs/database/src/core-results/dto/create-core-result.dto.ts
+++ b/libs/database/src/core-results/dto/create-core-result.dto.ts
@@ -1,4 +1,7 @@
 export class CreateCoreResultDto {
   websiteId: number;
   finalUrl: string;
+  finalUrlIsLive: boolean;
+  finalUrlBaseDomain: string;
+  targetUrlRedirects: boolean;
 }

--- a/libs/database/src/database.module.ts
+++ b/libs/database/src/database.module.ts
@@ -18,7 +18,8 @@ const ScannerDatabase = TypeOrmModule.forRootAsync({
       type: 'postgres',
       url: configService.get<string>('database.url'),
       entities: [Website, CoreResult],
-      synchronize: true,
+      synchronize: true, // do not use this in production
+      dropSchema: true, // do not use this in production
     };
   },
   inject: [ConfigService],


### PR DESCRIPTION
**Why**: This adds the basic fields to the `CoreScanner` and updates the `CoreResult` entity and related services to use the new data. 

**How**: Update `CoreResult` entity, update the `CoreResult` service, and update the `CoreScanner`. 

**Tags**: core, scanner