### PR TITLE
Close the puppeteer page after scanning.

### DIFF
--- a/libs/core-scanner/src/core-scanner.service.ts
+++ b/libs/core-scanner/src/core-scanner.service.ts
@@ -36,6 +36,9 @@ export class CoreScannerService
       finalUrlBaseDomain: this.getBaseDomain(finalUrl),
     };
 
+    await page.close();
+    this.logger.debug('closed puppeteer page');
+
     this.logger.debug(`result for ${input.url}: ${JSON.stringify(result)}`);
     return result;
   }


### PR DESCRIPTION
Why: I believe not calling `page.close` was causing a memory leak. This closes the a page after the scan. 

How: Add the `page.close` call in the `CoreScanner`. Add test to check that it is called.

Tags: puppeteer, memory leak, memory, core, core scanner