### PR TITLE
Add initial Target URL generation capability

### DIFF
--- a/apps/cli/src/app.module.ts
+++ b/apps/cli/src/app.module.ts
@@ -1,0 +1,9 @@
+import { IngestModule } from '@app/ingest';
+import { Module } from '@nestjs/common';
+import { IngestController } from './ingest.controller';
+
+@Module({
+  imports: [IngestModule],
+  controllers: [IngestController],
+})
+export class AppModule {}

--- a/apps/cli/src/ingest.controller.spec.ts
+++ b/apps/cli/src/ingest.controller.spec.ts
@@ -23,8 +23,9 @@ describe('IngestController', () => {
   });
 
   describe('root', () => {
-    it('should call writeUrls', () => {
-      expect(ingestController.writeUrls).toHaveBeenCalled();
+    it('should writes Urls', async () => {
+      await ingestController.writeUrls();
+      expect(mockIngestService.writeUrls).toHaveBeenCalled();
     });
   });
 });

--- a/apps/cli/src/ingest.controller.spec.ts
+++ b/apps/cli/src/ingest.controller.spec.ts
@@ -1,0 +1,30 @@
+import { IngestService } from '@app/ingest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MockProxy, mock } from 'jest-mock-extended';
+import { IngestController } from './ingest.controller';
+
+describe('IngestController', () => {
+  let ingestController: IngestController;
+  let mockIngestService: MockProxy<IngestService>;
+
+  beforeEach(async () => {
+    mockIngestService = mock<IngestService>();
+    const app: TestingModule = await Test.createTestingModule({
+      controllers: [IngestController],
+      providers: [
+        {
+          provide: IngestService,
+          useValue: mockIngestService,
+        },
+      ],
+    }).compile();
+
+    ingestController = app.get<IngestController>(IngestController);
+  });
+
+  describe('root', () => {
+    it('should call writeUrls', () => {
+      expect(ingestController.writeUrls).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/cli/src/ingest.controller.ts
+++ b/apps/cli/src/ingest.controller.ts
@@ -1,0 +1,11 @@
+import { IngestService } from '@app/ingest';
+import { Controller } from '@nestjs/common';
+
+@Controller()
+export class IngestController {
+  constructor(private readonly ingestService: IngestService) {}
+
+  async writeUrls() {
+    this.ingestService.writeUrls();
+  }
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,0 +1,34 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { IngestController } from './ingest.controller';
+import { Command } from 'commander';
+
+async function bootstrap() {
+  const app = await NestFactory.createApplicationContext(AppModule);
+  return app;
+}
+
+async function ingest() {
+  const nestApp = await bootstrap();
+  const controller = nestApp.get(IngestController);
+  console.log('ingesting target urls');
+  await controller.writeUrls();
+}
+
+async function main() {
+  const program = new Command();
+  program.version('0.0.1');
+  program.description(
+    'A command line interface for the site-scanning application.',
+  );
+
+  // ingest
+  program
+    .command('ingest')
+    .description('ingest adds target urls to the Website database table')
+    .action(ingest);
+
+  await program.parseAsync(process.argv);
+}
+
+main();

--- a/apps/cli/test/app.e2e-spec.ts
+++ b/apps/cli/test/app.e2e-spec.ts
@@ -1,0 +1,23 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule } from './../src/app.module';
+
+describe('AppController (e2e)', () => {
+  let app;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('/ (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/')
+      .expect(200)
+      .expect('Hello World!');
+  });
+});

--- a/apps/cli/test/app.e2e-spec.ts
+++ b/apps/cli/test/app.e2e-spec.ts
@@ -1,9 +1,11 @@
+import { INestApplicationContext } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import { IngestController } from '../src/ingest.controller';
 import { AppModule } from './../src/app.module';
 
-describe('AppController (e2e)', () => {
-  let app;
+describe('IngestController (e2e)', () => {
+  let app: INestApplicationContext;
+  let ingestController: IngestController;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -12,12 +14,10 @@ describe('AppController (e2e)', () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
+    ingestController = app.get(IngestController);
   });
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
+  it('writes urls', async () => {
+    await ingestController.writeUrls();
   });
 });

--- a/apps/cli/test/jest-e2e.json
+++ b/apps/cli/test/jest-e2e.json
@@ -1,0 +1,9 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  }
+}

--- a/apps/cli/tsconfig.app.json
+++ b/apps/cli/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "outDir": "../../dist/apps/cli"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -8,6 +8,7 @@ The current applications are:
 * [The Scan Engine](../apps/scan-engine) which listens to the message queue and routes work to the appropriate scanner.
 * [The  Producer](../apps/producer) which uses CRON to schedule jobs on the message queue. 
 * [The API](../apps/api) which is responsible for managing HTTPS access to the data.
+* [The CLI](../apps/cli) which is a general purpose CLI for interacting with the site scanner components. Currently used to ingest the Target URLs that the site scanner uses.
 
 See each of the applications' `README.md`s for more info.
 

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -26,6 +26,7 @@ The libraries are:
 * [Database](../libs/database) which is responsible for all data access. 
 * [Message Queue](../libs/message-queue) which is responsible for handling the message queue.
 * [Logger](../libs/logger) which is responsible for handling application logging.
+* [Ingest](../libs/ingest) which is responsible for ingesting data into the system. Currently, it handles target urls.
 
 #### Adding a new Library
 To add a new library, use the Nest.js CLI to scaffold the library.

--- a/libs/core-scanner/src/core-scanner.service.ts
+++ b/libs/core-scanner/src/core-scanner.service.ts
@@ -19,8 +19,11 @@ export class CoreScannerService
   async scan(input: CoreInputDto) {
     const page = await this.browser.newPage();
 
-    this.logger.debug(`loading ${input.url}`);
-    const response = await page.goto(input.url);
+    const url = this.getHttpsUrls(input.url);
+
+    this.logger.debug(`loading ${url}`);
+
+    const response = await page.goto(url);
     const redirects = response.request().redirectChain();
 
     redirects.forEach(req => {
@@ -39,7 +42,7 @@ export class CoreScannerService
     await page.close();
     this.logger.debug('closed puppeteer page');
 
-    this.logger.debug(`result for ${input.url}: ${JSON.stringify(result)}`);
+    this.logger.debug(`result for ${url}: ${JSON.stringify(result)}`);
     return result;
   }
 
@@ -53,6 +56,14 @@ export class CoreScannerService
   private getFinalUrl(page: Page) {
     const finalUrl = page.url();
     return finalUrl;
+  }
+
+  private getHttpsUrls(url: string) {
+    if (!url.startsWith('https://')) {
+      return `https://${url.toLowerCase()}`;
+    } else {
+      return url.toLowerCase();
+    }
   }
 
   private isLive(res: Response) {

--- a/libs/database/src/websites/dto/create-website.dto.ts
+++ b/libs/database/src/websites/dto/create-website.dto.ts
@@ -3,6 +3,10 @@
  */
 export class CreateWebsiteDto {
   url: string;
+  type: string;
   agency: string;
-  branch: string;
+  organization: string;
+  city: string;
+  state: string;
+  securityContactEmail: string;
 }

--- a/libs/database/src/websites/website.entity.ts
+++ b/libs/database/src/websites/website.entity.ts
@@ -21,8 +21,20 @@ export class Website {
   url: string;
 
   @Column()
+  type: string;
+
+  @Column()
   agency: string;
 
   @Column()
-  branch: string;
+  organization: string;
+
+  @Column()
+  city: string;
+
+  @Column()
+  state: string;
+
+  @Column()
+  securityContactEmail: string;
 }

--- a/libs/database/src/websites/website.module.ts
+++ b/libs/database/src/websites/website.module.ts
@@ -6,6 +6,6 @@ import { WebsiteService } from './websites.service';
 @Module({
   imports: [TypeOrmModule.forFeature([Website])],
   providers: [WebsiteService],
-  exports: [TypeOrmModule],
+  exports: [TypeOrmModule, WebsiteService],
 })
 export class WebsiteModule {}

--- a/libs/database/src/websites/websites.service.spec.ts
+++ b/libs/database/src/websites/websites.service.spec.ts
@@ -1,6 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { lookup } from 'dns';
 import { mock, MockProxy, mockReset } from 'jest-mock-extended';
 import { Repository } from 'typeorm';
 import { CreateWebsiteDto } from './dto/create-website.dto';
@@ -57,14 +56,22 @@ describe('WebsiteService', () => {
   it('should create a Website', async () => {
     const createWebsiteDto: CreateWebsiteDto = {
       url: 'https://18f.gov',
-      agency: 'GSA',
-      branch: 'Executive',
+      type: 'Federal Agency - Executive',
+      agency: 'General Services Administration',
+      organization: 'GSA,FAS,Technology Transformation Service',
+      city: 'Washington',
+      state: 'DC',
+      securityContactEmail: 'gsa-vulnerability-reports@gsa.gov',
     };
 
     const website = new Website();
     website.url = createWebsiteDto.url;
+    website.type = createWebsiteDto.type;
     website.agency = createWebsiteDto.agency;
-    website.branch = createWebsiteDto.branch;
+    website.organization = createWebsiteDto.organization;
+    website.city = createWebsiteDto.city;
+    website.state = createWebsiteDto.state;
+    website.securityContactEmail = createWebsiteDto.securityContactEmail;
 
     await service.create(createWebsiteDto);
     expect(mockRepository.save).toHaveBeenCalledWith(website);

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -24,7 +24,12 @@ export class WebsiteService {
     const website = new Website();
     website.url = createWebsiteDto.url;
     website.agency = createWebsiteDto.agency;
-    website.branch = createWebsiteDto.branch;
+    website.organization = createWebsiteDto.organization;
+    website.type = createWebsiteDto.type;
+    website.city = createWebsiteDto.city;
+    website.state = createWebsiteDto.state;
+    website.securityContactEmail = createWebsiteDto.securityContactEmail;
+
     await this.website.save(website);
   }
 }

--- a/libs/ingest/src/index.ts
+++ b/libs/ingest/src/index.ts
@@ -1,0 +1,2 @@
+export * from './ingest.module';
+export * from './ingest.service';

--- a/libs/ingest/src/ingest.module.ts
+++ b/libs/ingest/src/ingest.module.ts
@@ -1,0 +1,12 @@
+import { DatabaseModule } from '@app/database';
+import { WebsiteModule } from '@app/database/websites/website.module';
+import { LoggerModule } from '@app/logger';
+import { HttpModule, Module } from '@nestjs/common';
+import { IngestService } from './ingest.service';
+
+@Module({
+  imports: [HttpModule, WebsiteModule, DatabaseModule, LoggerModule],
+  providers: [IngestService],
+  exports: [IngestService],
+})
+export class IngestModule {}

--- a/libs/ingest/src/ingest.service.spec.ts
+++ b/libs/ingest/src/ingest.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { IngestService } from './ingest.service';
+
+describe('IngestService', () => {
+  let service: IngestService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [IngestService],
+    }).compile();
+
+    service = module.get<IngestService>(IngestService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/libs/ingest/src/ingest.service.spec.ts
+++ b/libs/ingest/src/ingest.service.spec.ts
@@ -1,12 +1,36 @@
+import { WebsiteService } from '@app/database/websites/websites.service';
+import { LoggerService } from '@app/logger';
+import { HttpService } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { mock, MockProxy } from 'jest-mock-extended';
 import { IngestService } from './ingest.service';
 
 describe('IngestService', () => {
   let service: IngestService;
+  let mockHttpService: MockProxy<HttpService>;
+  let mockWebsiteService: MockProxy<WebsiteService>;
+  let mockLogger: MockProxy<LoggerService>;
 
   beforeEach(async () => {
+    mockHttpService = mock<HttpService>();
+    mockWebsiteService = mock<WebsiteService>();
+    mockLogger = mock<LoggerService>();
     const module: TestingModule = await Test.createTestingModule({
-      providers: [IngestService],
+      providers: [
+        IngestService,
+        {
+          provide: WebsiteService,
+          useValue: mockWebsiteService,
+        },
+        {
+          provide: LoggerService,
+          useValue: mockLogger,
+        },
+        {
+          provide: HttpService,
+          useValue: mockHttpService,
+        },
+      ],
     }).compile();
 
     service = module.get<IngestService>(IngestService);

--- a/libs/ingest/src/ingest.service.ts
+++ b/libs/ingest/src/ingest.service.ts
@@ -1,0 +1,58 @@
+import { WebsiteService } from '@app/database/websites/websites.service';
+import { HttpService, Injectable } from '@nestjs/common';
+import { map } from 'rxjs/operators';
+import { parse } from '@fast-csv/parse';
+import { CreateWebsiteDto } from '@app/database/websites/dto/create-website.dto';
+import { LoggerService } from '@app/logger';
+
+@Injectable()
+export class IngestService {
+  constructor(
+    private httpService: HttpService,
+    private websiteService: WebsiteService,
+    private logger: LoggerService,
+  ) {
+    this.logger.setContext(IngestService.name);
+  }
+
+  private federalUrls =
+    'https://raw.githubusercontent.com/GSA/data/master/dotgov-domains/current-federal.csv';
+
+  private async getUrls() {
+    const urls = await this.httpService
+      .get(this.federalUrls)
+      .pipe(map(resp => resp.data))
+      .toPromise();
+    return urls;
+  }
+
+  /**
+   * writeUrls writes target urls to the Websites table.
+   */
+  async writeUrls() {
+    const stream = parse<CreateWebsiteDto, CreateWebsiteDto>({
+      headers: [
+        'url',
+        'type',
+        'agency',
+        'organization',
+        'city',
+        'state',
+        'securityContactEmail',
+      ],
+      renameHeaders: true,
+    })
+      .on('error', error => this.logger.error(error.message, error.stack))
+      .on('data', async (row: CreateWebsiteDto) => {
+        await this.websiteService.create(row);
+      })
+      .on('end', (rowCount: number) => {
+        this.logger.debug(rowCount);
+      });
+
+    const urls = await this.getUrls();
+
+    stream.write(urls);
+    stream.end();
+  }
+}

--- a/libs/ingest/tsconfig.lib.json
+++ b/libs/ingest/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "../../dist/libs/ingest"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -79,6 +79,24 @@
       "compilerOptions": {
         "tsConfigPath": "apps/scan-engine/tsconfig.app.json"
       }
+    },
+    "ingest": {
+      "type": "library",
+      "root": "libs/ingest",
+      "entryFile": "index",
+      "sourceRoot": "libs/ingest/src",
+      "compilerOptions": {
+        "tsConfigPath": "libs/ingest/tsconfig.lib.json"
+      }
+    },
+    "cli": {
+      "type": "application",
+      "root": "apps/cli",
+      "entryFile": "main",
+      "sourceRoot": "apps/cli/src",
+      "compilerOptions": {
+        "tsConfigPath": "apps/cli/tsconfig.app.json"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -637,6 +637,31 @@
         "minimist": "^1.2.0"
       }
     },
+    "@fast-csv/format": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.1.tgz",
+      "integrity": "sha512-Ap6KSt0iJlzrivZU4grQzDGGOQ+vN5kvUeOHLF1BE7nWri1auiodgS3SCffvLe1Zvu79tACe1tw3dyBADk1NsA==",
+      "requires": {
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "@fast-csv/parse": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.2.tgz",
+      "integrity": "sha512-smFKL1E00zy6SB+MIRL4kJq4ba4Is9mHEf+1kdMH7iLInrKszADyJFGicoRfiFTtAvm+661LJMWjyQHrmx6WeA==",
+      "requires": {
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1641,6 +1666,12 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
           "dev": true
         },
         "has-flag": {
@@ -3909,10 +3940,9 @@
       }
     },
     "commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -6024,6 +6054,23 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
+    },
+    "fast-csv": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.2.tgz",
+      "integrity": "sha512-tmvVMsliprsl7P1z++XuhfGZPTz/h2sTLhs5PYVhtOSsu7t0T2q1TdWq/CORQsD9Cc2oPiTchpf7gACLXArNYQ==",
+      "requires": {
+        "@fast-csv/format": "4.3.1",
+        "@fast-csv/parse": "4.3.2",
+        "@types/node": "^14.0.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.14.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.3.tgz",
+          "integrity": "sha512-33/L34xS7HVUx23e0wOT2V1qPF1IrHgQccdJVm9uXGTB9vFBrrzBtkQymT8VskeKOxjz55MSqMv0xuLq+u98WQ=="
+        }
+      }
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -10073,6 +10120,11 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
+    "lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+    },
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
@@ -10082,6 +10134,36 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
+    },
+    "lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw="
+    },
+    "lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha1-I+89lTVWUgOmbO/VuDD4SJEa+0g="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -10105,6 +10187,11 @@
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
       "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "log-symbols": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "rmdist": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"apps/**/*.ts\" \"libs/**/*.ts\"",
+    "ingest": "nest start cli -- ingest",
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
@@ -34,7 +35,9 @@
     "@nestjs/typeorm": "^7.1.4",
     "bull": "^3.18.0",
     "class-validator": "^0.12.2",
+    "commander": "^6.2.0",
     "cron": "^1.8.2",
+    "fast-csv": "^4.3.2",
     "http-status-codes": "^2.1.4",
     "lodash": "^4.17.20",
     "pg": "^8.4.0",
@@ -100,7 +103,9 @@
       "@app/browser/(.*)": "<rootDir>/libs/browser/src/$1",
       "@app/browser": "<rootDir>/libs/browser/src",
       "@app/core-scanner/(.*)": "<rootDir>/libs/core-scanner/src/$1",
-      "@app/core-scanner": "<rootDir>/libs/core-scanner/src"
+      "@app/core-scanner": "<rootDir>/libs/core-scanner/src",
+      "@app/ingest/(.*)": "<rootDir>/libs/ingest/src/$1",
+      "@app/ingest": "<rootDir>/libs/ingest/src"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "start:all": "concurrently \"npm run start producer\" \"npm run start scan-engine\" \"npm run start api\"",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
-    "test:no-e2e": "jest --testPathIgnorePatterns ./apps/**/test/*",
+    "test:unit": "jest --testPathIgnorePatterns ./apps/**/test/*",
+    "test:e2e": "jest ./apps/**/test/",
     "test:watch": "jest --watch --testPathIgnorePatterns ./apps/**/test/*",
     "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./apps/**/test/jest-e2e.json"
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
   },
   "dependencies": {
     "@nestjs/bull": "^0.2.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,12 @@
       ],
       "@app/core-scanner/*": [
         "libs/core-scanner/src/*"
+      ],
+      "@app/ingest": [
+        "libs/ingest/src"
+      ],
+      "@app/ingest/*": [
+        "libs/ingest/src/*"
       ]
     }
   }


### PR DESCRIPTION
**Why**: We need a way to repeatably add target urls for the scanner to scan. This commit adds a few things in service of that goal: 

- An `IngestService` that can be used for any kind of data ingest into the
system. In this commit it is used to add target urls to the Website table which the scanner consumes.

- A general-purpose `CLI` for the site-scanner. In this commit it is being used to call
the `IngestService` and add target urls to the scanner.

- Updates to the `Website` model to include new fields from the GSA dataset. 

- A fix to the `CoreScanner` to prepend "https" to the target url.

**Tags**: target urls, core scanner, ingest, cli, docs

