### PR TITLE
Add 404 Test.

### DIFF
--- a/entities/core-result.entity.ts
+++ b/entities/core-result.entity.ts
@@ -66,6 +66,10 @@ export class CoreResult {
   finalUrlSameWebsite?: boolean;
 
   @Column({ nullable: true })
+  @Expose({ name: 'target_url_404_test ' })
+  targetUrl404Test?: boolean;
+
+  @Column({ nullable: true })
   @Expose({ name: 'target_url_redirects' })
   targetUrlRedirects?: boolean;
 }

--- a/libs/core-scanner/src/core-scanner.module.ts
+++ b/libs/core-scanner/src/core-scanner.module.ts
@@ -1,11 +1,11 @@
 import { BrowserModule, BrowserService } from '@app/browser';
 import { LoggerModule } from '@app/logger';
-import { Module } from '@nestjs/common';
+import { HttpModule, Module } from '@nestjs/common';
 import { CoreScannerService } from './core-scanner.service';
 
 @Module({
-  imports: [BrowserModule, LoggerModule],
+  imports: [BrowserModule, LoggerModule, HttpModule],
   providers: [CoreScannerService, BrowserService],
-  exports: [CoreScannerService, BrowserModule],
+  exports: [CoreScannerService, BrowserModule, HttpModule],
 })
 export class CoreScannerModule {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1701,6 +1701,13 @@
         "iterare": "1.2.1",
         "tslib": "2.0.1",
         "uuid": "8.3.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
+        }
       }
     },
     "@nestjs/config": {
@@ -1734,6 +1741,13 @@
         "path-to-regexp": "3.2.0",
         "tslib": "2.0.1",
         "uuid": "8.3.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
+        }
       }
     },
     "@nestjs/platform-express": {
@@ -1764,6 +1778,11 @@
           "requires": {
             "moment-timezone": "^0.5.x"
           }
+        },
+        "uuid": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
         }
       }
     },
@@ -1902,6 +1921,13 @@
       "integrity": "sha512-3U4RKpyeig4NsOTxFhLtGcFM5Pm8Nv86GpdBlwEwBPqCnLxrUN7cgsXChWRFCV8GWd0QJnpZvGeaRpArt49Abg==",
       "requires": {
         "uuid": "8.3.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
+        }
       }
     },
     "@nuxtjs/opencollective": {
@@ -2256,6 +2282,12 @@
           "dev": true
         }
       }
+    },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+      "dev": true
     },
     "@types/validator": {
       "version": "13.0.0",
@@ -14145,9 +14177,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "puppeteer": "^5.3.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^6.5.4",
-    "typeorm": "^0.2.28"
+    "typeorm": "^0.2.28",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^7.0.0",
@@ -62,6 +63,7 @@
     "@types/node": "^13.9.1",
     "@types/puppeteer": "^3.0.2",
     "@types/supertest": "^2.0.8",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "3.9.1",
     "@typescript-eslint/parser": "3.9.1",
     "concurrently": "^5.3.0",


### PR DESCRIPTION
Why: This tests that a `target_url` returns a 404 when given a page that doesn't exist. The current methodology is just to add a path `not_found_test_{uuid}` with a random uuid generated. 

How: Add an axios get call to the core scanner. Add tests.

Tags: core scanner, not found test, uuid, 404