### PR TITLE
Empty queue on start

### DIFF
--- a/apps/producer/src/producer/producer.service.ts
+++ b/apps/producer/src/producer/producer.service.ts
@@ -30,9 +30,17 @@ export class ProducerService {
   }
 
   /**
-   * `empty` clears the queue. Note that stalled or delayed jobs are not emptied.
+   * `emptyAndClean` clears the queue and cleans up old jobs.
    */
-  async empty() {
+  async emptyAndClean() {
     await this.scannerQueue.empty();
+    await Promise.all([
+      this.scannerQueue.clean(0, 'active'),
+      this.scannerQueue.clean(0, 'completed'),
+      this.scannerQueue.clean(0, 'delayed'),
+      this.scannerQueue.clean(0, 'failed'),
+      this.scannerQueue.clean(0, 'paused'),
+      this.scannerQueue.clean(0, 'wait'),
+    ]);
   }
 }

--- a/apps/producer/src/task/task.service.ts
+++ b/apps/producer/src/task/task.service.ts
@@ -20,6 +20,10 @@ export class TaskService {
   }
 
   async start() {
+    // first clear out the queue
+    await this.producerService.empty();
+    this.logger.debug('producer queue emptied.');
+
     const schedule =
       this.configService.get('CORE_SCAN_SCHEDULE') || '0 0 * * *';
     this.logger.debug(`using schedule ${schedule}`);
@@ -34,8 +38,6 @@ export class TaskService {
 
   async coreScanProducer() {
     try {
-      await this.producerService.empty();
-
       const websites = await this.websiteService.findAll();
       websites.forEach(website => {
         const coreInput: CoreInputDto = {

--- a/apps/producer/src/task/task.service.ts
+++ b/apps/producer/src/task/task.service.ts
@@ -21,7 +21,7 @@ export class TaskService {
 
   async start() {
     // first clear out the queue
-    await this.producerService.empty();
+    await this.producerService.emptyAndClean();
     this.logger.debug('producer queue emptied.');
 
     const schedule =


### PR DESCRIPTION
Why: Empty the queue on start. This ensures that we're not using stale job data with incorrect website ids.

How: Call the `empty` and `clean` methods from the `bull` redis library.

Tags: bull, queue, empty, clean