### PR TITLE
Add USWDS Scan

### DIFF
--- a/entities/uswds-result.entity.ts
+++ b/entities/uswds-result.entity.ts
@@ -56,4 +56,8 @@ export class UswdsResult {
   @Column({ nullable: true })
   @Expose({ name: 'uswds_favicon_in_css' })
   uswdsUsFlagInCss?: number;
+
+  @Column({ nullable: true })
+  @Expose({ name: 'uswds_merriweather_font' })
+  uswdsMerriweatherFont?: number;
 }

--- a/entities/uswds-result.entity.ts
+++ b/entities/uswds-result.entity.ts
@@ -52,4 +52,8 @@ export class UswdsResult {
   @Column({ nullable: true })
   @Expose({ name: 'uswds_string_in_css' })
   uswdsStringInCss?: number;
+
+  @Column({ nullable: true })
+  @Expose({ name: 'uswds_favicon_in_css' })
+  uswdsUsFlagInCss?: number;
 }

--- a/entities/uswds-result.entity.ts
+++ b/entities/uswds-result.entity.ts
@@ -44,4 +44,8 @@ export class UswdsResult {
   @Column({ nullable: true })
   @Expose({ name: 'uswds_usa' })
   uswdsInlineCss?: number;
+
+  @Column({ nullable: true })
+  @Expose({ name: 'uswds_favicon' })
+  uswdsUsFlag?: number;
 }

--- a/entities/uswds-result.entity.ts
+++ b/entities/uswds-result.entity.ts
@@ -36,4 +36,8 @@ export class UswdsResult {
   @Column({ nullable: true })
   @Expose({ name: 'uswds_string' })
   uswdsString?: number;
+
+  @Column({ nullable: true })
+  @Expose({ name: 'uswds_tables' })
+  uswdsTables?: number;
 }

--- a/entities/uswds-result.entity.ts
+++ b/entities/uswds-result.entity.ts
@@ -48,4 +48,8 @@ export class UswdsResult {
   @Column({ nullable: true })
   @Expose({ name: 'uswds_favicon' })
   uswdsUsFlag?: number;
+
+  @Column({ nullable: true })
+  @Expose({ name: 'uswds_string_in_css' })
+  uswdsStringInCss?: number;
 }

--- a/entities/uswds-result.entity.ts
+++ b/entities/uswds-result.entity.ts
@@ -68,4 +68,8 @@ export class UswdsResult {
   @Column({ nullable: true })
   @Expose({ name: 'uswds_source_sans_font' })
   uswdsSourceSansFont?: number;
+
+  @Column({ nullable: true })
+  @Expose({ name: 'uswds_count' })
+  uswdsCount?: number;
 }

--- a/entities/uswds-result.entity.ts
+++ b/entities/uswds-result.entity.ts
@@ -40,4 +40,8 @@ export class UswdsResult {
   @Column({ nullable: true })
   @Expose({ name: 'uswds_tables' })
   uswdsTables?: number;
+
+  @Column({ nullable: true })
+  @Expose({ name: 'uswds_usa' })
+  uswdsInlineCss?: number;
 }

--- a/entities/uswds-result.entity.ts
+++ b/entities/uswds-result.entity.ts
@@ -1,0 +1,38 @@
+import { Exclude, Expose } from 'class-transformer';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Website } from './website.entity';
+
+@Entity()
+export class UswdsResult {
+  @PrimaryGeneratedColumn()
+  @Exclude({ toPlainOnly: true })
+  id: number;
+
+  @CreateDateColumn()
+  @Exclude({ toPlainOnly: true })
+  created: string;
+
+  @UpdateDateColumn()
+  @Exclude({ toPlainOnly: true })
+  updated: string;
+
+  @OneToOne(() => Website)
+  @JoinColumn()
+  @Exclude({ toPlainOnly: true })
+  website: Website;
+
+  /**
+   * usaClassesDetected contributes to overall score.
+   */
+  @Column({ nullable: true })
+  @Expose({ name: 'uswds_usa_classes_detected' })
+  usaClassesDetected?: number;
+}

--- a/entities/uswds-result.entity.ts
+++ b/entities/uswds-result.entity.ts
@@ -64,4 +64,8 @@ export class UswdsResult {
   @Column({ nullable: true })
   @Expose({ name: 'uswds_publicsans_font' })
   uswdsPublicSansFont?: number;
+
+  @Column({ nullable: true })
+  @Expose({ name: 'uswds_source_sans_font' })
+  uswdsSourceSansFont?: number;
 }

--- a/entities/uswds-result.entity.ts
+++ b/entities/uswds-result.entity.ts
@@ -29,10 +29,11 @@ export class UswdsResult {
   @Exclude({ toPlainOnly: true })
   website: Website;
 
-  /**
-   * usaClassesDetected contributes to overall score.
-   */
   @Column({ nullable: true })
-  @Expose({ name: 'uswds_usa_classes_detected' })
-  usaClassesDetected?: number;
+  @Expose({ name: 'uswds_usa_classes' })
+  usaClasses?: number;
+
+  @Column({ nullable: true })
+  @Expose({ name: 'uswds_string' })
+  uswdsString?: number;
 }

--- a/entities/uswds-result.entity.ts
+++ b/entities/uswds-result.entity.ts
@@ -60,4 +60,8 @@ export class UswdsResult {
   @Column({ nullable: true })
   @Expose({ name: 'uswds_merriweather_font' })
   uswdsMerriweatherFont?: number;
+
+  @Column({ nullable: true })
+  @Expose({ name: 'uswds_publicsans_font' })
+  uswdsPublicSansFont?: number;
 }

--- a/libs/uswds-scanner/src/index.ts
+++ b/libs/uswds-scanner/src/index.ts
@@ -1,0 +1,2 @@
+export * from './uswds-scanner.module';
+export * from './uswds-scanner.service';

--- a/libs/uswds-scanner/src/uswds-scanner.module.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { UswdsScannerService } from './uswds-scanner.service';
+
+@Module({
+  providers: [UswdsScannerService],
+  exports: [UswdsScannerService],
+})
+export class UswdsScannerModule {}

--- a/libs/uswds-scanner/src/uswds-scanner.module.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.module.ts
@@ -1,9 +1,10 @@
 import { BrowserModule } from '@app/browser';
+import { LoggerModule } from '@app/logger';
 import { Module } from '@nestjs/common';
 import { UswdsScannerService } from './uswds-scanner.service';
 
 @Module({
-  imports: [BrowserModule],
+  imports: [BrowserModule, LoggerModule],
   providers: [UswdsScannerService],
   exports: [UswdsScannerService],
 })

--- a/libs/uswds-scanner/src/uswds-scanner.module.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.module.ts
@@ -1,7 +1,9 @@
+import { BrowserModule } from '@app/browser';
 import { Module } from '@nestjs/common';
 import { UswdsScannerService } from './uswds-scanner.service';
 
 @Module({
+  imports: [BrowserModule],
   providers: [UswdsScannerService],
   exports: [UswdsScannerService],
 })

--- a/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
@@ -67,7 +67,8 @@ describe('UswdsScannerService', () => {
     expected.uswdsTables = -10;
     expected.uswdsInlineCss = 1;
     expected.uswdsUsFlag = 20;
-    expected.uswdsStringInCss = 0; // need to mock this eventually
+    expected.uswdsStringInCss = 0; // :TODO mock this
+    expected.uswdsUsFlagInCss = 0; // :TODO mock this
 
     expect(result).toStrictEqual(expected);
   });

--- a/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
@@ -67,6 +67,7 @@ describe('UswdsScannerService', () => {
     expected.uswdsTables = -10;
     expected.uswdsInlineCss = 1;
     expected.uswdsUsFlag = 20;
+    expected.uswdsStringInCss = 0; // need to mock this eventually
 
     expect(result).toStrictEqual(expected);
   });

--- a/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
@@ -70,6 +70,7 @@ describe('UswdsScannerService', () => {
     expected.uswdsStringInCss = 0; // :TODO mock this
     expected.uswdsUsFlagInCss = 0; // :TODO mock this
     expected.uswdsMerriweatherFont = 0; // :TODO mock this
+    expected.uswdsPublicSansFont = 0;
 
     expect(result).toStrictEqual(expected);
   });

--- a/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
@@ -53,7 +53,9 @@ describe('UswdsScannerService', () => {
     website.id = input.websiteId;
 
     mockPage.evaluate.mockResolvedValue(4);
-    mockResponse.text.mockResolvedValue('uswds uswds <table> .usa-');
+    mockResponse.text.mockResolvedValue(
+      'uswds uswds <table> .usa- us_flag_small.png',
+    );
     mockPage.goto.mockResolvedValue(mockResponse);
 
     const result = await service.scan(input);
@@ -64,6 +66,7 @@ describe('UswdsScannerService', () => {
     expected.uswdsString = 2;
     expected.uswdsTables = -10;
     expected.uswdsInlineCss = 1;
+    expected.uswdsUsFlag = 20;
 
     expect(result).toStrictEqual(expected);
   });

--- a/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
@@ -1,4 +1,5 @@
 import { BROWSER_TOKEN } from '@app/browser';
+import { LoggerService } from '@app/logger';
 import { Test, TestingModule } from '@nestjs/testing';
 import { UswdsResult } from 'entities/uswds-result.entity';
 import { Website } from 'entities/website.entity';
@@ -11,11 +12,13 @@ describe('UswdsScannerService', () => {
   let service: UswdsScannerService;
   let mockBrowser: MockProxy<Browser>;
   let mockPage: MockProxy<Page>;
+  let mockLogger: MockProxy<LoggerService>;
 
   beforeEach(async () => {
     mockBrowser = mock<Browser>();
     mockPage = mock<Page>();
     mockBrowser.newPage.calledWith().mockResolvedValue(mockPage);
+    mockLogger = mock<LoggerService>();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -23,6 +26,10 @@ describe('UswdsScannerService', () => {
         {
           provide: BROWSER_TOKEN,
           useValue: mockBrowser,
+        },
+        {
+          provide: LoggerService,
+          useValue: mockLogger,
         },
       ],
     }).compile();

--- a/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
@@ -4,7 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UswdsResult } from 'entities/uswds-result.entity';
 import { Website } from 'entities/website.entity';
 import { mock, MockProxy } from 'jest-mock-extended';
-import { Browser, Page } from 'puppeteer';
+import { Browser, Page, Response } from 'puppeteer';
 import { UswdsScannerService } from './uswds-scanner.service';
 import { UswdsInputDto } from './uswds.input.dto';
 
@@ -13,10 +13,12 @@ describe('UswdsScannerService', () => {
   let mockBrowser: MockProxy<Browser>;
   let mockPage: MockProxy<Page>;
   let mockLogger: MockProxy<LoggerService>;
+  let mockResponse: MockProxy<Response>;
 
   beforeEach(async () => {
     mockBrowser = mock<Browser>();
     mockPage = mock<Page>();
+    mockResponse = mock<Response>();
     mockBrowser.newPage.calledWith().mockResolvedValue(mockPage);
     mockLogger = mock<LoggerService>();
 
@@ -51,12 +53,15 @@ describe('UswdsScannerService', () => {
     website.id = input.websiteId;
 
     mockPage.evaluate.mockResolvedValue(4);
+    mockResponse.text.mockResolvedValue('uswds is uswds');
+    mockPage.goto.mockResolvedValue(mockResponse);
 
     const result = await service.scan(input);
     const expected = new UswdsResult();
 
     expected.website = website;
-    expected.usaClassesDetected = 4;
+    expected.usaClasses = 4;
+    expected.uswdsString = 2;
 
     expect(result).toStrictEqual(expected);
   });

--- a/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
@@ -1,12 +1,30 @@
+import { BROWSER_TOKEN } from '@app/browser';
 import { Test, TestingModule } from '@nestjs/testing';
+import { UswdsResult } from 'entities/uswds-result.entity';
+import { Website } from 'entities/website.entity';
+import { mock, MockProxy } from 'jest-mock-extended';
+import { Browser, Page } from 'puppeteer';
 import { UswdsScannerService } from './uswds-scanner.service';
+import { UswdsInputDto } from './uswds.input.dto';
 
 describe('UswdsScannerService', () => {
   let service: UswdsScannerService;
+  let mockBrowser: MockProxy<Browser>;
+  let mockPage: MockProxy<Page>;
 
   beforeEach(async () => {
+    mockBrowser = mock<Browser>();
+    mockPage = mock<Page>();
+    mockBrowser.newPage.calledWith().mockResolvedValue(mockPage);
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UswdsScannerService],
+      providers: [
+        UswdsScannerService,
+        {
+          provide: BROWSER_TOKEN,
+          useValue: mockBrowser,
+        },
+      ],
     }).compile();
 
     service = module.get<UswdsScannerService>(UswdsScannerService);
@@ -14,5 +32,25 @@ describe('UswdsScannerService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should return whether usa- is found in class selectors', async () => {
+    const input: UswdsInputDto = {
+      websiteId: 1,
+      url: '18f.gov',
+    };
+
+    const website = new Website();
+    website.id = input.websiteId;
+
+    mockPage.evaluate.mockResolvedValue(4);
+
+    const result = await service.scan(input);
+    const expected = new UswdsResult();
+
+    expected.website = website;
+    expected.usaClassesDetected = 4;
+
+    expect(result).toStrictEqual(expected);
   });
 });

--- a/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
@@ -70,7 +70,8 @@ describe('UswdsScannerService', () => {
     expected.uswdsStringInCss = 0; // :TODO mock this
     expected.uswdsUsFlagInCss = 0; // :TODO mock this
     expected.uswdsMerriweatherFont = 0; // :TODO mock this
-    expected.uswdsPublicSansFont = 0;
+    expected.uswdsPublicSansFont = 0; // :TODO mock this
+    expected.uswdsSourceSansFont = 0; // :TODO mock this
 
     expect(result).toStrictEqual(expected);
   });

--- a/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
@@ -43,7 +43,7 @@ describe('UswdsScannerService', () => {
     expect(service).toBeDefined();
   });
 
-  it('should return whether usa- is found in class selectors', async () => {
+  it('should return the correct response', async () => {
     const input: UswdsInputDto = {
       websiteId: 1,
       url: '18f.gov',
@@ -53,7 +53,7 @@ describe('UswdsScannerService', () => {
     website.id = input.websiteId;
 
     mockPage.evaluate.mockResolvedValue(4);
-    mockResponse.text.mockResolvedValue('uswds is uswds');
+    mockResponse.text.mockResolvedValue('uswds is uswds <table');
     mockPage.goto.mockResolvedValue(mockResponse);
 
     const result = await service.scan(input);
@@ -62,6 +62,7 @@ describe('UswdsScannerService', () => {
     expected.website = website;
     expected.usaClasses = 4;
     expected.uswdsString = 2;
+    expected.uswdsTables = -10;
 
     expect(result).toStrictEqual(expected);
   });

--- a/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
@@ -72,6 +72,7 @@ describe('UswdsScannerService', () => {
     expected.uswdsMerriweatherFont = 0; // :TODO mock this
     expected.uswdsPublicSansFont = 0; // :TODO mock this
     expected.uswdsSourceSansFont = 0; // :TODO mock this
+    expected.uswdsCount = 17;
 
     expect(result).toStrictEqual(expected);
   });

--- a/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
@@ -69,6 +69,7 @@ describe('UswdsScannerService', () => {
     expected.uswdsUsFlag = 20;
     expected.uswdsStringInCss = 0; // :TODO mock this
     expected.uswdsUsFlagInCss = 0; // :TODO mock this
+    expected.uswdsMerriweatherFont = 0; // :TODO mock this
 
     expect(result).toStrictEqual(expected);
   });

--- a/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
@@ -53,7 +53,7 @@ describe('UswdsScannerService', () => {
     website.id = input.websiteId;
 
     mockPage.evaluate.mockResolvedValue(4);
-    mockResponse.text.mockResolvedValue('uswds is uswds <table');
+    mockResponse.text.mockResolvedValue('uswds uswds <table> .usa-');
     mockPage.goto.mockResolvedValue(mockResponse);
 
     const result = await service.scan(input);
@@ -63,6 +63,7 @@ describe('UswdsScannerService', () => {
     expected.usaClasses = 4;
     expected.uswdsString = 2;
     expected.uswdsTables = -10;
+    expected.uswdsInlineCss = 1;
 
     expect(result).toStrictEqual(expected);
   });

--- a/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UswdsScannerService } from './uswds-scanner.service';
+
+describe('UswdsScannerService', () => {
+  let service: UswdsScannerService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UswdsScannerService],
+    }).compile();
+
+    service = module.get<UswdsScannerService>(UswdsScannerService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/libs/uswds-scanner/src/uswds-scanner.service.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.ts
@@ -4,6 +4,7 @@ import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { Scanner } from 'common/interfaces/scanner.interface';
 import { UswdsResult } from 'entities/uswds-result.entity';
 import { Website } from 'entities/website.entity';
+import { sum } from 'lodash';
 import { Browser } from 'puppeteer';
 import { UswdsInputDto } from './uswds.input.dto';
 
@@ -47,16 +48,39 @@ export class UswdsScannerService
 
     const htmlText = await response.text();
 
+    const uswdsInHtml = this.uswdsInHtml(htmlText);
+    const uswdsTables = this.tableCount(htmlText);
+    const inlineCssCount = this.inlineUsaCssCount(htmlText);
+    const usFlagHtml = this.uswdsFlagDetected(htmlText);
+    const usFlagCss = this.uswdsFlagInCSS(cssPages);
+    const uswdsCss = this.uswdsInCss(cssPages);
+    const merriweatherFont = this.uswdsMerriweatherFont(cssPages);
+    const publicSansFont = this.uswdsPublicSansFont(cssPages);
+    const sourceSansFont = this.uswdsSourceSansFont(cssPages);
+    const uswdsCount = sum([
+      usaClassesCount,
+      uswdsInHtml,
+      uswdsTables,
+      inlineCssCount,
+      usFlagHtml,
+      usFlagCss,
+      uswdsCss,
+      merriweatherFont,
+      sourceSansFont,
+      publicSansFont,
+    ]);
+
     result.usaClasses = usaClassesCount;
-    result.uswdsString = this.uswdsInHtml(htmlText);
-    result.uswdsTables = this.tableCount(htmlText);
-    result.uswdsInlineCss = this.inlineUsaCssCount(htmlText);
-    result.uswdsUsFlag = this.uswdsFlagDetected(htmlText);
-    result.uswdsStringInCss = this.uswdsInCss(cssPages);
-    result.uswdsUsFlagInCss = this.uswdsFlagInCSS(cssPages);
-    result.uswdsMerriweatherFont = this.uswdsMerriweatherFont(cssPages);
-    result.uswdsPublicSansFont = this.uswdsPublicSansFont(cssPages);
-    result.uswdsSourceSansFont = this.uswdsSourceSansFont(cssPages);
+    result.uswdsString = uswdsInHtml;
+    result.uswdsTables = uswdsTables;
+    result.uswdsInlineCss = inlineCssCount;
+    result.uswdsUsFlag = usFlagHtml;
+    result.uswdsUsFlagInCss = usFlagCss;
+    result.uswdsStringInCss = uswdsCss;
+    result.uswdsMerriweatherFont = merriweatherFont;
+    result.uswdsPublicSansFont = publicSansFont;
+    result.uswdsSourceSansFont = sourceSansFont;
+    result.uswdsCount = uswdsCount;
 
     await this.browser.close();
     return result;

--- a/libs/uswds-scanner/src/uswds-scanner.service.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.ts
@@ -55,6 +55,7 @@ export class UswdsScannerService
     result.uswdsStringInCss = this.uswdsInCss(cssPages);
     result.uswdsUsFlagInCss = this.uswdsFlagInCSS(cssPages);
     result.uswdsMerriweatherFont = this.uswdsMerriweatherFont(cssPages);
+    result.uswdsPublicSansFont = this.uswdsPublicSansFont(cssPages);
 
     await this.browser.close();
     return result;
@@ -153,6 +154,21 @@ export class UswdsScannerService
       const match = page.match(re);
       if (match) {
         score = 5;
+        break;
+      }
+    }
+
+    return score;
+  }
+
+  private uswdsPublicSansFont(cssPages: string[]) {
+    const re = /[Pp]ublic.[Ss]ans/;
+    let score = 0;
+
+    for (const page of cssPages) {
+      const match = page.match(re);
+      if (match) {
+        score = 20;
         break;
       }
     }

--- a/libs/uswds-scanner/src/uswds-scanner.service.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.ts
@@ -38,8 +38,11 @@ export class UswdsScannerService
       return score;
     });
 
+    const htmlText = await response.text();
+
     result.usaClasses = usaClassesCount;
-    result.uswdsString = this.uswdsInHtml(await response.text());
+    result.uswdsString = this.uswdsInHtml(htmlText);
+    result.uswdsTables = this.tableCount(htmlText);
 
     await this.browser.close();
     return result;
@@ -57,6 +60,31 @@ export class UswdsScannerService
     const re = /uswds/g;
     const occurrenceCount = [...htmlText.matchAll(re)].length;
     this.logger.debug(`uswds occurs ${occurrenceCount} times`);
+    return occurrenceCount;
+  }
+
+  /**
+   * tableCount detects the presence of <table> elements in HTML. This is a negative indicator of USWDS.
+   *
+   * @param htmlText html in text.
+   */
+  private tableCount(htmlText: string) {
+    const re = /<table/g;
+    const occurrenceCount = [...htmlText.matchAll(re)].length;
+    let deduction = 0;
+
+    if (occurrenceCount > 0) {
+      const tableDeduction = -10;
+      deduction = tableDeduction * occurrenceCount;
+    }
+
+    return deduction;
+  }
+
+  private inlineUsaCSS(htmlText: string) {
+    const re = /\.usa-/;
+    const occurrenceCount = [...htmlText.matchAll(re)].length;
+
     return occurrenceCount;
   }
 

--- a/libs/uswds-scanner/src/uswds-scanner.service.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.ts
@@ -1,16 +1,19 @@
 import { BROWSER_TOKEN } from '@app/browser';
+import { LoggerService } from '@app/logger';
 import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { Scanner } from 'common/interfaces/scanner.interface';
 import { UswdsResult } from 'entities/uswds-result.entity';
 import { Website } from 'entities/website.entity';
-import { round } from 'lodash';
 import { Browser } from 'puppeteer';
 import { UswdsInputDto } from './uswds.input.dto';
 
 @Injectable()
 export class UswdsScannerService
   implements Scanner<UswdsInputDto, UswdsResult>, OnModuleDestroy {
-  constructor(@Inject(BROWSER_TOKEN) private browser: Browser) {}
+  constructor(
+    @Inject(BROWSER_TOKEN) private browser: Browser,
+    private logger: LoggerService,
+  ) {}
 
   async scan(input: UswdsInputDto): Promise<UswdsResult> {
     const page = await this.browser.newPage();
@@ -29,7 +32,7 @@ export class UswdsScannerService
       let score = 0;
 
       if (usaClasses.length > 0) {
-        score = round(Math.sqrt(usaClasses.length)) * 5;
+        score = Math.round(Math.sqrt(usaClasses.length)) * 5;
       }
 
       return score;

--- a/libs/uswds-scanner/src/uswds-scanner.service.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.ts
@@ -1,0 +1,55 @@
+import { BROWSER_TOKEN } from '@app/browser';
+import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
+import { Scanner } from 'common/interfaces/scanner.interface';
+import { UswdsResult } from 'entities/uswds-result.entity';
+import { Website } from 'entities/website.entity';
+import { round } from 'lodash';
+import { Browser } from 'puppeteer';
+import { UswdsInputDto } from './uswds.input.dto';
+
+@Injectable()
+export class UswdsScannerService
+  implements Scanner<UswdsInputDto, UswdsResult>, OnModuleDestroy {
+  constructor(@Inject(BROWSER_TOKEN) private browser: Browser) {}
+
+  async scan(input: UswdsInputDto): Promise<UswdsResult> {
+    const page = await this.browser.newPage();
+
+    const result = new UswdsResult();
+    const website = new Website();
+    website.id = input.websiteId;
+
+    result.website = website;
+
+    const url = this.getHttpsUrls(input.url);
+    await page.goto(url);
+
+    const usaClasses = await page.evaluate(() => {
+      return document.querySelectorAll("[class^='usa-']");
+    });
+    result.usaClassesDetected = this.uswdsUsaClasses(usaClasses);
+
+    await this.browser.close();
+    return result;
+  }
+
+  private getHttpsUrls(url: string) {
+    if (!url.startsWith('https://')) {
+      return `https://${url.toLowerCase()}`;
+    } else {
+      return url.toLowerCase();
+    }
+  }
+
+  private uswdsUsaClasses(usaClasses: NodeListOf<Element>) {
+    let score = 0;
+    if (usaClasses.length > 0) {
+      score = round(Math.sqrt(usaClasses.length)) * 5;
+    }
+    return score;
+  }
+
+  async onModuleDestroy() {
+    await this.browser.close();
+  }
+}

--- a/libs/uswds-scanner/src/uswds-scanner.service.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.ts
@@ -56,6 +56,7 @@ export class UswdsScannerService
     result.uswdsUsFlagInCss = this.uswdsFlagInCSS(cssPages);
     result.uswdsMerriweatherFont = this.uswdsMerriweatherFont(cssPages);
     result.uswdsPublicSansFont = this.uswdsPublicSansFont(cssPages);
+    result.uswdsSourceSansFont = this.uswdsSourceSansFont(cssPages);
 
     await this.browser.close();
     return result;
@@ -169,6 +170,21 @@ export class UswdsScannerService
       const match = page.match(re);
       if (match) {
         score = 20;
+        break;
+      }
+    }
+
+    return score;
+  }
+
+  private uswdsSourceSansFont(cssPages: string[]) {
+    const re = /[Ss]ource.[Ss]ans.[Pp]ro/;
+    let score = 0;
+
+    for (const page of cssPages) {
+      const match = page.match(re);
+      if (match) {
+        score = 5;
         break;
       }
     }

--- a/libs/uswds-scanner/src/uswds-scanner.service.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.ts
@@ -25,7 +25,7 @@ export class UswdsScannerService
     result.website = website;
 
     const url = this.getHttpsUrls(input.url);
-    await page.goto(url);
+    const response = await page.goto(url);
 
     const usaClassesCount = await page.evaluate(() => {
       const usaClasses = [...document.querySelectorAll("[class^='usa-']")];
@@ -38,7 +38,8 @@ export class UswdsScannerService
       return score;
     });
 
-    result.usaClassesDetected = usaClassesCount;
+    result.usaClasses = usaClassesCount;
+    result.uswdsString = this.uswdsInHtml(await response.text());
 
     await this.browser.close();
     return result;
@@ -50,6 +51,13 @@ export class UswdsScannerService
     } else {
       return url.toLowerCase();
     }
+  }
+
+  private uswdsInHtml(htmlText: string) {
+    const re = /uswds/g;
+    const occurrenceCount = [...htmlText.matchAll(re)].length;
+    this.logger.debug(`uswds occurs ${occurrenceCount} times`);
+    return occurrenceCount;
   }
 
   async onModuleDestroy() {

--- a/libs/uswds-scanner/src/uswds-scanner.service.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.ts
@@ -53,6 +53,7 @@ export class UswdsScannerService
     result.uswdsInlineCss = this.inlineUsaCssCount(htmlText);
     result.uswdsUsFlag = this.uswdsFlagDetected(htmlText);
     result.uswdsStringInCss = this.uswdsInCss(cssPages);
+    result.uswdsUsFlagInCss = this.uswdsFlagInCSS(cssPages);
 
     await this.browser.close();
     return result;
@@ -119,6 +120,22 @@ export class UswdsScannerService
     for (const page of cssPages) {
       const occurrenceCount = [...page.matchAll(re)].length;
       score += occurrenceCount;
+    }
+
+    return score;
+  }
+
+  private uswdsFlagInCSS(cssPages: string[]) {
+    // these are the asset names of the small us flag in the USA Header for differnt uswds versions and devices.
+    const re = /us_flag_small.png|favicon-57.png|favicon-192.png|favicon-72.png|favicon-144.png|favicon-114.png/;
+    let score = 0;
+
+    for (const page of cssPages) {
+      const match = page.match(re);
+      if (match) {
+        score = 20;
+        break;
+      }
     }
 
     return score;

--- a/libs/uswds-scanner/src/uswds-scanner.service.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.ts
@@ -43,6 +43,7 @@ export class UswdsScannerService
     result.usaClasses = usaClassesCount;
     result.uswdsString = this.uswdsInHtml(htmlText);
     result.uswdsTables = this.tableCount(htmlText);
+    result.uswdsInlineCss = this.inlineUsaCSS(htmlText);
 
     await this.browser.close();
     return result;

--- a/libs/uswds-scanner/src/uswds-scanner.service.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.ts
@@ -54,6 +54,7 @@ export class UswdsScannerService
     result.uswdsUsFlag = this.uswdsFlagDetected(htmlText);
     result.uswdsStringInCss = this.uswdsInCss(cssPages);
     result.uswdsUsFlagInCss = this.uswdsFlagInCSS(cssPages);
+    result.uswdsMerriweatherFont = this.uswdsMerriweatherFont(cssPages);
 
     await this.browser.close();
     return result;
@@ -115,11 +116,14 @@ export class UswdsScannerService
 
   private uswdsInCss(cssPages: string[]) {
     let score = 0;
-    const re = /uswds/gi;
+    const re = /uswds/i;
 
     for (const page of cssPages) {
-      const occurrenceCount = [...page.matchAll(re)].length;
-      score += occurrenceCount;
+      const match = page.match(re);
+      if (match) {
+        score = 20;
+        break;
+      }
     }
 
     return score;
@@ -134,6 +138,21 @@ export class UswdsScannerService
       const match = page.match(re);
       if (match) {
         score = 20;
+        break;
+      }
+    }
+
+    return score;
+  }
+
+  private uswdsMerriweatherFont(cssPages: string[]) {
+    const re = /[Mm]erriweather/;
+    let score = 0;
+
+    for (const page of cssPages) {
+      const match = page.match(re);
+      if (match) {
+        score = 5;
         break;
       }
     }

--- a/libs/uswds-scanner/src/uswds-scanner.service.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.ts
@@ -43,7 +43,8 @@ export class UswdsScannerService
     result.usaClasses = usaClassesCount;
     result.uswdsString = this.uswdsInHtml(htmlText);
     result.uswdsTables = this.tableCount(htmlText);
-    result.uswdsInlineCss = this.inlineUsaCSS(htmlText);
+    result.uswdsInlineCss = this.inlineUsaCssCount(htmlText);
+    result.uswdsUsFlag = this.uswdsFlagDetected(htmlText);
 
     await this.browser.close();
     return result;
@@ -82,11 +83,25 @@ export class UswdsScannerService
     return deduction;
   }
 
-  private inlineUsaCSS(htmlText: string) {
-    const re = /\.usa-/;
+  private inlineUsaCssCount(htmlText: string) {
+    const re = /\.usa-/g;
     const occurrenceCount = [...htmlText.matchAll(re)].length;
 
     return occurrenceCount;
+  }
+
+  private uswdsFlagDetected(htmlText: string) {
+    // these are the asset names of the small us flag in the USA Header for differnt uswds versions and devices.
+    const re = /us_flag_small.png|favicon-57.png|favicon-192.png|favicon-72.png|favicon-144.png|favicon-114.png/;
+
+    // all we need is one match to give the points;
+    const occurrenceCount = htmlText.match(re);
+    let score = 0;
+
+    if (occurrenceCount) {
+      score = 20;
+    }
+    return score;
   }
 
   async onModuleDestroy() {

--- a/libs/uswds-scanner/src/uswds-scanner.service.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.ts
@@ -24,10 +24,18 @@ export class UswdsScannerService
     const url = this.getHttpsUrls(input.url);
     await page.goto(url);
 
-    const usaClasses = await page.evaluate(() => {
-      return document.querySelectorAll("[class^='usa-']");
+    const usaClassesCount = await page.evaluate(() => {
+      const usaClasses = [...document.querySelectorAll("[class^='usa-']")];
+      let score = 0;
+
+      if (usaClasses.length > 0) {
+        score = round(Math.sqrt(usaClasses.length)) * 5;
+      }
+
+      return score;
     });
-    result.usaClassesDetected = this.uswdsUsaClasses(usaClasses);
+
+    result.usaClassesDetected = usaClassesCount;
 
     await this.browser.close();
     return result;
@@ -39,14 +47,6 @@ export class UswdsScannerService
     } else {
       return url.toLowerCase();
     }
-  }
-
-  private uswdsUsaClasses(usaClasses: NodeListOf<Element>) {
-    let score = 0;
-    if (usaClasses.length > 0) {
-      score = round(Math.sqrt(usaClasses.length)) * 5;
-    }
-    return score;
   }
 
   async onModuleDestroy() {

--- a/libs/uswds-scanner/src/uswds.input.dto.ts
+++ b/libs/uswds-scanner/src/uswds.input.dto.ts
@@ -1,0 +1,21 @@
+import { IsNumber, IsUrl } from 'class-validator';
+
+/**
+ * UswdsInputDto is a Data Transfer Object for input to the UswdsScanner.
+ */
+export class UswdsInputDto {
+  /**
+   * websiteId is the id of the Website that we are scanning for. This is needed for creating one-to-one relations
+   * between results and websites.
+   */
+  @IsNumber()
+  websiteId: number;
+
+  /**
+   * url is a string representing a url of a website in the Federal Web Presence (.gov, .mil, etc.)
+   *
+   * @remarks This string is validated to be an actual URL.
+   */
+  @IsUrl()
+  url: string;
+}

--- a/libs/uswds-scanner/test/app.e2e-spec.ts
+++ b/libs/uswds-scanner/test/app.e2e-spec.ts
@@ -1,0 +1,39 @@
+import { UswdsScannerModule, UswdsScannerService } from '@app/uswds-scanner';
+import { UswdsInputDto } from '@app/uswds-scanner/uswds.input.dto';
+import { Test, TestingModule } from '@nestjs/testing';
+import { UswdsResult } from 'entities/uswds-result.entity';
+import { Website } from 'entities/website.entity';
+
+describe('UswdsScanner (e2e)', () => {
+  let service: UswdsScannerService;
+  let moduleFixture: TestingModule;
+
+  beforeEach(async () => {
+    moduleFixture = await Test.createTestingModule({
+      imports: [UswdsScannerModule],
+    }).compile();
+
+    service = moduleFixture.get<UswdsScannerService>(UswdsScannerService);
+  });
+
+  afterAll(async () => {
+    await service.onModuleDestroy();
+    await moduleFixture.close();
+  });
+
+  it('returns results for a url', async () => {
+    const input: UswdsInputDto = {
+      websiteId: 1,
+      url: '18f.gov',
+    };
+    const website = new Website();
+    website.id = input.websiteId;
+
+    const expected = new UswdsResult();
+    expected.website = website;
+    expected.usaClassesDetected = 50;
+
+    const result = await service.scan(input);
+    expect(result).toStrictEqual(expected);
+  });
+});

--- a/libs/uswds-scanner/test/app.e2e-spec.ts
+++ b/libs/uswds-scanner/test/app.e2e-spec.ts
@@ -31,7 +31,8 @@ describe('UswdsScanner (e2e)', () => {
 
     const expected = new UswdsResult();
     expected.website = website;
-    expected.usaClassesDetected = 50;
+    expected.usaClasses = 50;
+    expected.uswdsString = 1;
 
     const result = await service.scan(input);
     expect(result).toStrictEqual(expected);

--- a/libs/uswds-scanner/test/app.e2e-spec.ts
+++ b/libs/uswds-scanner/test/app.e2e-spec.ts
@@ -36,8 +36,9 @@ describe('UswdsScanner (e2e)', () => {
     expected.uswdsTables = 0;
     expected.uswdsInlineCss = 0;
     expected.uswdsUsFlag = 20;
-    expected.uswdsStringInCss = 33;
+    expected.uswdsStringInCss = 20;
     expected.uswdsUsFlagInCss = 0;
+    expected.uswdsMerriweatherFont = 5;
 
     const result = await service.scan(input);
     expect(result).toStrictEqual(expected);

--- a/libs/uswds-scanner/test/app.e2e-spec.ts
+++ b/libs/uswds-scanner/test/app.e2e-spec.ts
@@ -34,6 +34,7 @@ describe('UswdsScanner (e2e)', () => {
     expected.usaClasses = 50;
     expected.uswdsString = 1;
     expected.uswdsTables = 0;
+    expected.uswdsInlineCss = 0;
 
     const result = await service.scan(input);
     expect(result).toStrictEqual(expected);

--- a/libs/uswds-scanner/test/app.e2e-spec.ts
+++ b/libs/uswds-scanner/test/app.e2e-spec.ts
@@ -33,6 +33,7 @@ describe('UswdsScanner (e2e)', () => {
     expected.website = website;
     expected.usaClasses = 50;
     expected.uswdsString = 1;
+    expected.uswdsTables = 0;
 
     const result = await service.scan(input);
     expect(result).toStrictEqual(expected);

--- a/libs/uswds-scanner/test/app.e2e-spec.ts
+++ b/libs/uswds-scanner/test/app.e2e-spec.ts
@@ -37,6 +37,7 @@ describe('UswdsScanner (e2e)', () => {
     expected.uswdsInlineCss = 0;
     expected.uswdsUsFlag = 20;
     expected.uswdsStringInCss = 33;
+    expected.uswdsUsFlagInCss = 0;
 
     const result = await service.scan(input);
     expect(result).toStrictEqual(expected);

--- a/libs/uswds-scanner/test/app.e2e-spec.ts
+++ b/libs/uswds-scanner/test/app.e2e-spec.ts
@@ -39,6 +39,7 @@ describe('UswdsScanner (e2e)', () => {
     expected.uswdsStringInCss = 20;
     expected.uswdsUsFlagInCss = 0;
     expected.uswdsMerriweatherFont = 5;
+    expected.uswdsPublicSansFont = 20;
 
     const result = await service.scan(input);
     expect(result).toStrictEqual(expected);

--- a/libs/uswds-scanner/test/app.e2e-spec.ts
+++ b/libs/uswds-scanner/test/app.e2e-spec.ts
@@ -36,6 +36,7 @@ describe('UswdsScanner (e2e)', () => {
     expected.uswdsTables = 0;
     expected.uswdsInlineCss = 0;
     expected.uswdsUsFlag = 20;
+    expected.uswdsStringInCss = 33;
 
     const result = await service.scan(input);
     expect(result).toStrictEqual(expected);

--- a/libs/uswds-scanner/test/app.e2e-spec.ts
+++ b/libs/uswds-scanner/test/app.e2e-spec.ts
@@ -40,6 +40,7 @@ describe('UswdsScanner (e2e)', () => {
     expected.uswdsUsFlagInCss = 0;
     expected.uswdsMerriweatherFont = 5;
     expected.uswdsPublicSansFont = 20;
+    expected.uswdsSourceSansFont = 5;
 
     const result = await service.scan(input);
     expect(result).toStrictEqual(expected);

--- a/libs/uswds-scanner/test/app.e2e-spec.ts
+++ b/libs/uswds-scanner/test/app.e2e-spec.ts
@@ -41,6 +41,7 @@ describe('UswdsScanner (e2e)', () => {
     expected.uswdsMerriweatherFont = 5;
     expected.uswdsPublicSansFont = 20;
     expected.uswdsSourceSansFont = 5;
+    expected.uswdsCount = 121;
 
     const result = await service.scan(input);
     expect(result).toStrictEqual(expected);

--- a/libs/uswds-scanner/test/app.e2e-spec.ts
+++ b/libs/uswds-scanner/test/app.e2e-spec.ts
@@ -35,6 +35,7 @@ describe('UswdsScanner (e2e)', () => {
     expected.uswdsString = 1;
     expected.uswdsTables = 0;
     expected.uswdsInlineCss = 0;
+    expected.uswdsUsFlag = 20;
 
     const result = await service.scan(input);
     expect(result).toStrictEqual(expected);

--- a/libs/uswds-scanner/test/jest-e2e.json
+++ b/libs/uswds-scanner/test/jest-e2e.json
@@ -1,0 +1,9 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  }
+}

--- a/libs/uswds-scanner/tsconfig.lib.json
+++ b/libs/uswds-scanner/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "../../dist/libs/uswds-scanner"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -97,6 +97,15 @@
       "compilerOptions": {
         "tsConfigPath": "apps/cli/tsconfig.app.json"
       }
+    },
+    "uswds-scanner": {
+      "type": "library",
+      "root": "libs/uswds-scanner",
+      "entryFile": "index",
+      "sourceRoot": "libs/uswds-scanner/src",
+      "compilerOptions": {
+        "tsConfigPath": "libs/uswds-scanner/tsconfig.lib.json"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -114,7 +114,9 @@
       "@app/core-scanner/(.*)": "<rootDir>/libs/core-scanner/src/$1",
       "@app/core-scanner": "<rootDir>/libs/core-scanner/src",
       "@app/ingest/(.*)": "<rootDir>/libs/ingest/src/$1",
-      "@app/ingest": "<rootDir>/libs/ingest/src"
+      "@app/ingest": "<rootDir>/libs/ingest/src",
+      "@app/uswds-scanner/(.*)": "<rootDir>/libs/uswds-scanner/src/$1",
+      "@app/uswds-scanner": "<rootDir>/libs/uswds-scanner/src"
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,6 +47,12 @@
       ],
       "@app/ingest/*": [
         "libs/ingest/src/*"
+      ],
+      "@app/uswds-scanner": [
+        "libs/uswds-scanner/src"
+      ],
+      "@app/uswds-scanner/*": [
+        "libs/uswds-scanner/src/*"
       ]
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,13 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "lib": [
+      "ES2020.String", 
+      "es5", 
+      "es6", 
+      "dom", 
+      "dom.iterable"
+    ],
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
**Why**: This adds a scanner and entity specifically for USWDS scans. This adapts Domain Scan's [USWDS2 scanner](https://github.com/18F/domain-scan/blob/master/scanners/uswds2.py). The basic idea behind this scanner is to heuristically determine the presence of USWDS on given website. It checks for the various characteristics that would likely be present on a site using USWDS and weights them accordingly. 

**How**: Add a new library `uswds-scanner` which implements the scanner interface. Add a new entity `uswds-result.entity.ts` which captures all of the fields. and various serialization methods.

Tags: uswds, scanner, entity, heuristic