### PR TITLE
Add USWDS to API results

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,15 +1,12 @@
 import { DatabaseModule } from '@app/database';
-import { WebsiteService } from '@app/database/websites/websites.service';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { RootController } from './root/root.controller';
 import { WebsiteController } from './website/website.controller';
 import { ResultsController } from './results/results.controller';
-import { CoreResultService } from '@app/database/core-results/core-result.service';
 
 @Module({
   imports: [ConfigModule.forRoot(), DatabaseModule],
   controllers: [WebsiteController, RootController, ResultsController],
-  providers: [WebsiteService, CoreResultService],
 })
 export class AppModule {}

--- a/apps/api/src/website/serializer.ts
+++ b/apps/api/src/website/serializer.ts
@@ -1,12 +1,14 @@
 import { classToPlain } from 'class-transformer';
-import { CoreResult } from 'entities/core-result.entity';
+import { Website } from 'entities/website.entity';
 
-function websiteSerializer(coreResult: CoreResult) {
-  const serializedCoreResult = classToPlain(coreResult);
-  const serializedWebsite = classToPlain(coreResult.website);
+function websiteSerializer(website: Website) {
+  const serializedWebsite = classToPlain(website);
+  const serializedCoreResult = classToPlain(website.coreResult);
+  const serializedUswdsResult = classToPlain(website.uswdsResult);
 
   return {
     ...serializedCoreResult,
+    ...serializedUswdsResult,
     ...serializedWebsite,
   };
 }

--- a/apps/api/src/website/website.controller.spec.ts
+++ b/apps/api/src/website/website.controller.spec.ts
@@ -5,25 +5,21 @@ import { mock, MockProxy, mockReset } from 'jest-mock-extended';
 import { WebsiteController } from './website.controller';
 import { CoreResult } from 'entities/core-result.entity';
 import { websiteSerializer } from './serializer';
+import { UswdsResult } from 'entities/uswds-result.entity';
+import { Website } from 'entities/website.entity';
 
 describe('WebsiteController', () => {
   let websiteController: WebsiteController;
   let mockWebsiteService: MockProxy<WebsiteService>;
-  let mockCoreResultsService: MockProxy<CoreResultService>;
 
   beforeEach(async () => {
     mockWebsiteService = mock<WebsiteService>();
-    mockCoreResultsService = mock<CoreResultService>();
     const app: TestingModule = await Test.createTestingModule({
       controllers: [WebsiteController],
       providers: [
         {
           provide: WebsiteService,
           useValue: mockWebsiteService,
-        },
-        {
-          provide: CoreResultService,
-          useValue: mockCoreResultsService,
         },
       ],
     }).compile();
@@ -39,13 +35,18 @@ describe('WebsiteController', () => {
     it('should return a list of results', async () => {
       const coreResult = new CoreResult();
       coreResult.id = 1;
+      const uswdsResult = new UswdsResult();
+      const website = new Website();
 
-      mockCoreResultsService.findResultsWithWebsite
+      website.coreResult = coreResult;
+      website.uswdsResult = uswdsResult;
+
+      mockWebsiteService.findAllWithResult
         .calledWith()
-        .mockResolvedValue(Promise.resolve([coreResult]));
+        .mockResolvedValue([website]);
 
       const result = await websiteController.getResults();
-      const serialized = websiteSerializer(coreResult);
+      const serialized = websiteSerializer(website);
 
       expect(result).toStrictEqual([serialized]);
     });

--- a/apps/api/src/website/website.controller.ts
+++ b/apps/api/src/website/website.controller.ts
@@ -1,4 +1,3 @@
-import { CoreResultService } from '@app/database/core-results/core-result.service';
 import { CreateWebsiteDto } from '@app/database/websites/dto/create-website.dto';
 import { WebsiteService } from '@app/database/websites/websites.service';
 import { Body, Controller, Get, Post } from '@nestjs/common';
@@ -7,14 +6,11 @@ import { map } from 'lodash';
 
 @Controller('websites')
 export class WebsiteController {
-  constructor(
-    private readonly websiteService: WebsiteService,
-    private readonly coreResultService: CoreResultService,
-  ) {}
+  constructor(private readonly websiteService: WebsiteService) {}
 
   @Get()
   async getResults() {
-    const websites = await this.coreResultService.findResultsWithWebsite();
+    const websites = await this.websiteService.findAllWithResult();
     const serialized = map(websites, websiteSerializer);
 
     return serialized;

--- a/apps/producer/src/producer/producer.service.ts
+++ b/apps/producer/src/producer/producer.service.ts
@@ -1,8 +1,13 @@
-import { CORE_SCAN_JOB_NAME, SCANNER_QUEUE_NAME } from '@app/message-queue';
+import {
+  CORE_SCAN_JOB_NAME,
+  SCANNER_QUEUE_NAME,
+  USWDS_SCAN_JOB_NAME,
+} from '@app/message-queue';
 import { InjectQueue } from '@nestjs/bull';
 import { Injectable } from '@nestjs/common';
 import { Queue } from 'bull';
 import { CoreInputDto } from '@app/core-scanner/core.input.dto';
+import { UswdsInputDto } from '@app/uswds-scanner/uswds.input.dto';
 
 /**
  * ProducerService writes jobs to the message queue.
@@ -26,6 +31,15 @@ export class ProducerService {
       removeOnComplete: true,
       attempts: 3,
     });
+    return job;
+  }
+
+  async addUswdsJob(uswdsInput: UswdsInputDto) {
+    const job = await this.scannerQueue.add(USWDS_SCAN_JOB_NAME, uswdsInput, {
+      removeOnComplete: true,
+      attempts: 3,
+    });
+
     return job;
   }
 

--- a/apps/producer/src/task/task.service.ts
+++ b/apps/producer/src/task/task.service.ts
@@ -6,6 +6,7 @@ import { SchedulerRegistry } from '@nestjs/schedule';
 import { CoreInputDto } from '@app/core-scanner/core.input.dto';
 import { ProducerService } from '../producer/producer.service';
 import { CronJob } from 'cron';
+import { UswdsInputDto } from '@app/uswds-scanner/uswds.input.dto';
 
 @Injectable()
 export class TaskService {
@@ -28,12 +29,12 @@ export class TaskService {
       this.configService.get<string>('CORE_SCAN_SCHEDULE') || '0 0 * * *';
     this.logger.debug(`using schedule ${schedule}`);
 
-    const job = new CronJob(schedule, async () => {
+    const coreJob = new CronJob(schedule, async () => {
       await this.coreScanProducer();
     });
 
-    this.scheduler.addCronJob('core-scan', job);
-    job.start();
+    this.scheduler.addCronJob('core-scan', coreJob);
+    coreJob.start();
   }
 
   async coreScanProducer() {
@@ -45,6 +46,12 @@ export class TaskService {
           url: website.url,
         };
         this.producerService.addCoreJob(coreInput);
+
+        const uswdsInput: UswdsInputDto = {
+          websiteId: website.id,
+          url: website.url,
+        };
+        this.producerService.addUswdsJob(uswdsInput);
       });
     } catch (error) {
       this.logger.error(`error in ${this.coreScanProducer.name}`, error);

--- a/apps/scan-engine/src/app.module.ts
+++ b/apps/scan-engine/src/app.module.ts
@@ -1,10 +1,9 @@
 import { DatabaseModule } from '@app/database';
-import { CoreResultService } from '@app/database/core-results/core-result.service';
-import { LoggerModule, LoggerService } from '@app/logger';
+import { LoggerModule } from '@app/logger';
 import { MessageQueueModule } from '@app/message-queue';
 import { UswdsScannerModule } from '@app/uswds-scanner';
 import { Module } from '@nestjs/common';
-import { CoreScannerModule, CoreScannerService } from 'libs/core-scanner/src';
+import { CoreScannerModule } from 'libs/core-scanner/src';
 import { ScanEngineConsumer } from './scan-engine.consumer';
 
 @Module({
@@ -15,11 +14,6 @@ import { ScanEngineConsumer } from './scan-engine.consumer';
     UswdsScannerModule,
     LoggerModule,
   ],
-  providers: [
-    CoreScannerService,
-    CoreResultService,
-    LoggerService,
-    ScanEngineConsumer,
-  ],
+  providers: [ScanEngineConsumer],
 })
 export class AppModule {}

--- a/apps/scan-engine/src/app.module.ts
+++ b/apps/scan-engine/src/app.module.ts
@@ -2,6 +2,7 @@ import { DatabaseModule } from '@app/database';
 import { CoreResultService } from '@app/database/core-results/core-result.service';
 import { LoggerModule, LoggerService } from '@app/logger';
 import { MessageQueueModule } from '@app/message-queue';
+import { UswdsScannerModule } from '@app/uswds-scanner';
 import { Module } from '@nestjs/common';
 import { CoreScannerModule, CoreScannerService } from 'libs/core-scanner/src';
 import { ScanEngineConsumer } from './scan-engine.consumer';
@@ -11,6 +12,7 @@ import { ScanEngineConsumer } from './scan-engine.consumer';
     MessageQueueModule,
     DatabaseModule,
     CoreScannerModule,
+    UswdsScannerModule,
     LoggerModule,
   ],
   providers: [

--- a/apps/scan-engine/src/scan-engine.consumer.spec.ts
+++ b/apps/scan-engine/src/scan-engine.consumer.spec.ts
@@ -8,19 +8,29 @@ import { CoreInputDto } from '@app/core-scanner/core.input.dto';
 import { Scanner } from 'common/interfaces/scanner.interface';
 import { CoreScannerService } from '@app/core-scanner';
 import { CoreResult } from 'entities/core-result.entity';
+import { UswdsResultService } from '@app/database/uswds-result/uswds-result.service';
+import { UswdsInputDto } from '@app/uswds-scanner/uswds.input.dto';
+import { UswdsResult } from 'entities/uswds-result.entity';
+import { UswdsScannerService } from '@app/uswds-scanner';
 
 describe('ScanEngineConsumer', () => {
   let consumer: ScanEngineConsumer;
   let module: TestingModule;
   let mockCoreScanner: MockProxy<Scanner<CoreInputDto, CoreResult>>;
   let mockCoreResultService: MockProxy<CoreResultService>;
-  let mockJob: MockProxy<Job<CoreInputDto>>;
+  let mockUswdsScanner: MockProxy<Scanner<UswdsInputDto, UswdsResult>>;
+  let mockUswdsResultService: MockProxy<UswdsResultService>;
+  let mockCoreJob: MockProxy<Job<CoreInputDto>>;
+  let mockUswdsJob: MockProxy<Job<UswdsInputDto>>;
   let mockLogger: MockProxy<LoggerService>;
 
   beforeEach(async () => {
     mockCoreScanner = mock<Scanner<CoreInputDto, CoreResult>>();
     mockCoreResultService = mock<CoreResultService>();
-    mockJob = mock<Job<CoreInputDto>>();
+    mockUswdsScanner = mock<Scanner<UswdsInputDto, UswdsResult>>();
+    mockUswdsResultService = mock<UswdsResultService>();
+    mockCoreJob = mock<Job<CoreInputDto>>();
+    mockUswdsJob = mock<Job<UswdsInputDto>>();
     mockLogger = mock<LoggerService>();
     module = await Test.createTestingModule({
       providers: [
@@ -34,6 +44,14 @@ describe('ScanEngineConsumer', () => {
           useValue: mockCoreResultService,
         },
         {
+          provide: UswdsScannerService,
+          useValue: mockUswdsScanner,
+        },
+        {
+          provide: UswdsResultService,
+          useValue: mockUswdsResultService,
+        },
+        {
           provide: LoggerService,
           useValue: mockLogger,
         },
@@ -41,12 +59,6 @@ describe('ScanEngineConsumer', () => {
     }).compile();
 
     consumer = module.get<ScanEngineConsumer>(ScanEngineConsumer);
-  });
-
-  afterEach(async () => {
-    mockReset(mockCoreScanner);
-    mockReset(mockJob);
-    mockReset(mockCoreResultService);
   });
 
   it('should be defined', () => {
@@ -59,15 +71,33 @@ describe('ScanEngineConsumer', () => {
       url: 'https://18f.gov',
     };
 
-    mockJob.data = input;
+    mockCoreJob.data = input;
 
     const coreResult = new CoreResult();
     coreResult.id = 1;
 
     mockCoreScanner.scan.calledWith(input).mockResolvedValue(coreResult);
-    await consumer.processCore(mockJob);
+    await consumer.processCore(mockCoreJob);
 
     expect(mockCoreScanner.scan).toHaveBeenCalledWith(input);
     expect(mockCoreResultService.create).toHaveBeenCalledWith(coreResult);
+  });
+
+  it('should call the UswdsScanner and UswdsResultService', async () => {
+    const input: UswdsInputDto = {
+      websiteId: 1,
+      url: 'https://18f.gov',
+    };
+
+    mockUswdsJob.data = input;
+
+    const uswdsResult = new UswdsResult();
+    uswdsResult.id = 1;
+
+    mockUswdsScanner.scan.calledWith(input).mockResolvedValue(uswdsResult);
+    await consumer.processUswds(mockUswdsJob);
+
+    expect(mockUswdsScanner.scan).toHaveBeenCalledWith(input);
+    expect(mockUswdsResultService.create).toHaveBeenLastCalledWith(uswdsResult);
   });
 });

--- a/apps/scan-engine/src/scan-engine.consumer.spec.ts
+++ b/apps/scan-engine/src/scan-engine.consumer.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { mock, mockReset, MockProxy } from 'jest-mock-extended';
+import { mock, MockProxy } from 'jest-mock-extended';
 import { ScanEngineConsumer } from './scan-engine.consumer';
 import { Job } from 'bull';
 import { CoreResultService } from '@app/database/core-results/core-result.service';

--- a/entities/core-result.entity.ts
+++ b/entities/core-result.entity.ts
@@ -24,7 +24,10 @@ export class CoreResult {
   @Expose({ name: 'scan_date' })
   updated: string;
 
-  @OneToOne(() => Website)
+  @OneToOne(
+    () => Website,
+    website => website.coreResult,
+  )
   @JoinColumn()
   @Exclude({ toPlainOnly: true })
   website: Website;

--- a/entities/uswds-result.entity.ts
+++ b/entities/uswds-result.entity.ts
@@ -24,7 +24,10 @@ export class UswdsResult {
   @Exclude({ toPlainOnly: true })
   updated: string;
 
-  @OneToOne(() => Website)
+  @OneToOne(
+    () => Website,
+    website => website.uswdsResult,
+  )
   @JoinColumn()
   @Exclude({ toPlainOnly: true })
   website: Website;

--- a/entities/uswds-result.entity.ts
+++ b/entities/uswds-result.entity.ts
@@ -32,6 +32,10 @@ export class UswdsResult {
   @Exclude({ toPlainOnly: true })
   website: Website;
 
+  @Column()
+  @Expose({ name: 'uswds_status' })
+  status: string;
+
   @Column({ nullable: true })
   @Expose({ name: 'uswds_usa_classes' })
   usaClasses?: number;

--- a/entities/website.entity.ts
+++ b/entities/website.entity.ts
@@ -3,9 +3,12 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  OneToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { CoreResult } from './core-result.entity';
+import { UswdsResult } from './uswds-result.entity';
 
 @Entity()
 export class Website {
@@ -20,6 +23,20 @@ export class Website {
   @UpdateDateColumn()
   @Exclude({ toPlainOnly: true })
   updated: string;
+
+  @OneToOne(
+    () => CoreResult,
+    coreResult => coreResult.website,
+  )
+  @Exclude({ toPlainOnly: true })
+  coreResult: CoreResult;
+
+  @OneToOne(
+    () => UswdsResult,
+    uswdsResult => uswdsResult.website,
+  )
+  @Exclude({ toPlainOnly: true })
+  uswdsResult: UswdsResult;
 
   @Column()
   @Expose({ name: 'target_url' })

--- a/libs/browser/src/browser.service.ts
+++ b/libs/browser/src/browser.service.ts
@@ -1,3 +1,4 @@
+import { ScanStatus } from '@app/core-scanner/scan-status';
 import * as puppeteer from 'puppeteer';
 
 /**
@@ -28,4 +29,24 @@ const BrowserService = {
   },
 };
 
-export { BROWSER_TOKEN, BrowserService };
+function parseBrowserError(err: Error) {
+  const dnsError = err.message.startsWith('net::ERR_NAME_NOT_RESOLVED');
+  const timeoutError = err.name === 'TimeoutError';
+  const sslError = err.message.startsWith('net::ERR_CERT_COMMON_NAME_INVALID');
+
+  let errorType: ScanStatus;
+
+  if (timeoutError) {
+    errorType = ScanStatus.Timeout;
+  } else if (dnsError) {
+    errorType = ScanStatus.DNSResolutionError;
+  } else if (sslError) {
+    errorType = ScanStatus.InvalidSSLCert;
+  } else {
+    errorType = ScanStatus.UnknownError;
+  }
+
+  return errorType;
+}
+
+export { BROWSER_TOKEN, BrowserService, parseBrowserError };

--- a/libs/database/src/core-results/core-result.module.ts
+++ b/libs/database/src/core-results/core-result.module.ts
@@ -6,6 +6,6 @@ import { CoreResultService } from './core-result.service';
 @Module({
   imports: [TypeOrmModule.forFeature([CoreResult])],
   providers: [CoreResultService],
-  exports: [TypeOrmModule],
+  exports: [TypeOrmModule, CoreResultService],
 })
 export class CoreResultModule {}

--- a/libs/database/src/database.module.ts
+++ b/libs/database/src/database.module.ts
@@ -6,6 +6,7 @@ import { WebsiteModule } from './websites/website.module';
 import dbconfig from './config/db.config';
 import { Website } from 'entities/website.entity';
 import { CoreResult } from 'entities/core-result.entity';
+import { UswdsResult } from 'entities/uswds-result.entity';
 
 const ScannerDatabase = TypeOrmModule.forRootAsync({
   imports: [
@@ -17,7 +18,7 @@ const ScannerDatabase = TypeOrmModule.forRootAsync({
     return {
       type: 'postgres',
       url: configService.get<string>('database.url'),
-      entities: [Website, CoreResult],
+      entities: [Website, CoreResult, UswdsResult],
       synchronize: true, // do not use this in production
       dropSchema: true, // do not use this in production
     };

--- a/libs/database/src/database.module.ts
+++ b/libs/database/src/database.module.ts
@@ -7,6 +7,7 @@ import dbconfig from './config/db.config';
 import { Website } from 'entities/website.entity';
 import { CoreResult } from 'entities/core-result.entity';
 import { UswdsResult } from 'entities/uswds-result.entity';
+import { UswdsResultModule } from './uswds-result/uswds-result.module';
 
 const ScannerDatabase = TypeOrmModule.forRootAsync({
   imports: [
@@ -27,8 +28,18 @@ const ScannerDatabase = TypeOrmModule.forRootAsync({
 });
 
 @Module({
-  imports: [ScannerDatabase, WebsiteModule, CoreResultModule],
+  imports: [
+    ScannerDatabase,
+    WebsiteModule,
+    CoreResultModule,
+    UswdsResultModule,
+  ],
   providers: [],
-  exports: [ScannerDatabase, WebsiteModule, CoreResultModule],
+  exports: [
+    ScannerDatabase,
+    WebsiteModule,
+    CoreResultModule,
+    UswdsResultModule,
+  ],
 })
 export class DatabaseModule {}

--- a/libs/database/src/uswds-result/uswds-result.module.ts
+++ b/libs/database/src/uswds-result/uswds-result.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UswdsResult } from 'entities/uswds-result.entity';
+import { UswdsResultService } from './uswds-result.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([UswdsResult])],
+  providers: [UswdsResultService],
+  exports: [TypeOrmModule],
+})
+export class UswdsResultModule {}

--- a/libs/database/src/uswds-result/uswds-result.module.ts
+++ b/libs/database/src/uswds-result/uswds-result.module.ts
@@ -6,6 +6,6 @@ import { UswdsResultService } from './uswds-result.service';
 @Module({
   imports: [TypeOrmModule.forFeature([UswdsResult])],
   providers: [UswdsResultService],
-  exports: [TypeOrmModule],
+  exports: [TypeOrmModule, UswdsResultService],
 })
 export class UswdsResultModule {}

--- a/libs/database/src/uswds-result/uswds-result.service.spec.ts
+++ b/libs/database/src/uswds-result/uswds-result.service.spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UswdsResult } from 'entities/uswds-result.entity';
+import { Website } from 'entities/website.entity';
+import { mock, MockProxy } from 'jest-mock-extended';
+import { Repository } from 'typeorm';
+import { UswdsResultService } from './uswds-result.service';
+
+describe('UswdsResultService', () => {
+  let service: UswdsResultService;
+  let mockRespository: MockProxy<Repository<UswdsResult>>;
+
+  beforeEach(async () => {
+    mockRespository = mock<Repository<UswdsResult>>();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UswdsResultService,
+        {
+          provide: getRepositoryToken(UswdsResult),
+          useValue: mockRespository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<UswdsResultService>(UswdsResultService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should return all UswdsResults', async () => {
+    const uswdsResult = new UswdsResult();
+    uswdsResult.uswdsCount = 100;
+
+    const expected = [uswdsResult];
+    mockRespository.find.calledWith().mockResolvedValue(expected);
+    const result = await service.findAll();
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('should return one UswdsResult by id', async () => {
+    const uswdsResult = new UswdsResult();
+    uswdsResult.id = 1;
+
+    mockRespository.findOne.calledWith().mockResolvedValue(uswdsResult);
+    const result = await service.findOne(1);
+
+    expect(result).toStrictEqual(result);
+  });
+
+  it('should create a UswdsResult', async () => {
+    const website = new Website();
+    website.id = 1;
+    const uswdsResult = new UswdsResult();
+    uswdsResult.id = 1;
+    uswdsResult.website = website;
+
+    await service.create(uswdsResult);
+    expect(mockRespository.save).toHaveBeenCalledWith(uswdsResult);
+  });
+});

--- a/libs/database/src/uswds-result/uswds-result.service.ts
+++ b/libs/database/src/uswds-result/uswds-result.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UswdsResult } from 'entities/uswds-result.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class UswdsResultService {
+  constructor(
+    @InjectRepository(UswdsResult) private uswdsResult: Repository<UswdsResult>,
+  ) {}
+
+  async findAll(): Promise<UswdsResult[]> {
+    const results = await this.uswdsResult.find();
+    return results;
+  }
+
+  async findOne(id: number): Promise<UswdsResult> {
+    const result = await this.uswdsResult.findOne(id);
+    return result;
+  }
+
+  async create(uswdsResult: UswdsResult) {
+    const exists = await this.uswdsResult.findOne({
+      where: {
+        website: {
+          id: uswdsResult.website.id,
+        },
+      },
+    });
+
+    if (exists) {
+      // then update
+      await this.uswdsResult.save({
+        ...exists,
+        ...uswdsResult,
+      });
+    } else {
+      await this.uswdsResult.save(uswdsResult);
+    }
+  }
+}

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -15,6 +15,13 @@ export class WebsiteService {
     return websites;
   }
 
+  async findAllWithResult(): Promise<Website[]> {
+    const result = await this.website.find({
+      relations: ['coreResult', 'uswdsResult'],
+    });
+    return result;
+  }
+
   async findOne(id: number): Promise<Website> {
     const website = await this.website.findOne(id);
     return website;

--- a/libs/message-queue/src/message-queue.module.ts
+++ b/libs/message-queue/src/message-queue.module.ts
@@ -5,6 +5,7 @@ import mqConfig from './config/mq.config';
 
 const SCANNER_QUEUE_NAME = 'ScannerQueue';
 const CORE_SCAN_JOB_NAME = 'core';
+const USWDS_SCAN_JOB_NAME = 'uswds';
 
 const ScannerQueue = BullModule.registerQueueAsync({
   name: SCANNER_QUEUE_NAME,
@@ -29,4 +30,4 @@ const ScannerQueue = BullModule.registerQueueAsync({
 })
 export class MessageQueueModule {}
 
-export { SCANNER_QUEUE_NAME, CORE_SCAN_JOB_NAME };
+export { SCANNER_QUEUE_NAME, CORE_SCAN_JOB_NAME, USWDS_SCAN_JOB_NAME };

--- a/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.spec.ts
@@ -1,4 +1,5 @@
 import { BROWSER_TOKEN } from '@app/browser';
+import { ScanStatus } from '@app/core-scanner/scan-status';
 import { LoggerService } from '@app/logger';
 import { Test, TestingModule } from '@nestjs/testing';
 import { UswdsResult } from 'entities/uswds-result.entity';
@@ -73,6 +74,7 @@ describe('UswdsScannerService', () => {
     expected.uswdsPublicSansFont = 0; // :TODO mock this
     expected.uswdsSourceSansFont = 0; // :TODO mock this
     expected.uswdsCount = 17;
+    expected.status = ScanStatus.Completed;
 
     expect(result).toStrictEqual(expected);
   });

--- a/libs/uswds-scanner/src/uswds-scanner.service.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.ts
@@ -1,11 +1,12 @@
-import { BROWSER_TOKEN } from '@app/browser';
+import { BROWSER_TOKEN, parseBrowserError } from '@app/browser';
+import { ScanStatus } from '@app/core-scanner/scan-status';
 import { LoggerService } from '@app/logger';
 import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { Scanner } from 'common/interfaces/scanner.interface';
 import { UswdsResult } from 'entities/uswds-result.entity';
 import { Website } from 'entities/website.entity';
 import { sum } from 'lodash';
-import { Browser } from 'puppeteer';
+import { Browser, Response } from 'puppeteer';
 import { UswdsInputDto } from './uswds.input.dto';
 
 @Injectable()
@@ -33,7 +34,19 @@ export class UswdsScannerService
     });
 
     const url = this.getHttpsUrls(input.url);
-    const response = await page.goto(url);
+
+    let response: Response;
+
+    try {
+      response = await page.goto(url);
+    } catch (e) {
+      const err = e as Error;
+      const errorType = parseBrowserError(err);
+      if (errorType === ScanStatus.UnknownError) {
+        this.logger.error(err.message, err.stack);
+      }
+      result.status = errorType;
+    }
 
     const usaClassesCount = await page.evaluate(() => {
       const usaClasses = [...document.querySelectorAll("[class^='usa-']")];
@@ -70,6 +83,7 @@ export class UswdsScannerService
       publicSansFont,
     ]);
 
+    result.status = ScanStatus.Completed;
     result.usaClasses = usaClassesCount;
     result.uswdsString = uswdsInHtml;
     result.uswdsTables = uswdsTables;
@@ -82,7 +96,7 @@ export class UswdsScannerService
     result.uswdsSourceSansFont = sourceSansFont;
     result.uswdsCount = uswdsCount;
 
-    await this.browser.close();
+    await page.close();
     return result;
   }
 

--- a/libs/uswds-scanner/src/uswds-scanner.service.ts
+++ b/libs/uswds-scanner/src/uswds-scanner.service.ts
@@ -46,6 +46,7 @@ export class UswdsScannerService
         this.logger.error(err.message, err.stack);
       }
       result.status = errorType;
+      return result;
     }
 
     const usaClassesCount = await page.evaluate(() => {

--- a/libs/uswds-scanner/test/app.e2e-spec.ts
+++ b/libs/uswds-scanner/test/app.e2e-spec.ts
@@ -1,3 +1,4 @@
+import { ScanStatus } from '@app/core-scanner/scan-status';
 import { UswdsScannerModule, UswdsScannerService } from '@app/uswds-scanner';
 import { UswdsInputDto } from '@app/uswds-scanner/uswds.input.dto';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -42,6 +43,7 @@ describe('UswdsScanner (e2e)', () => {
     expected.uswdsPublicSansFont = 20;
     expected.uswdsSourceSansFont = 5;
     expected.uswdsCount = 121;
+    expected.status = ScanStatus.Completed;
 
     const result = await service.scan(input);
     expect(result).toStrictEqual(expected);


### PR DESCRIPTION
Why: This adds the USWDS scan data to the API. I made a few changes in design to accommodate this.

1) The big change is querying `Websites` instead of `CoreResults` and joining `CoreResult` and `UswdsResult` to `Websites`. I added bi-directional OneToOne fields on the results and on Website. This way we can maintain the simple serialization at the API edge. 

2) I added another `Job` type to the producer and consumer. With this we can scan for USWDS on a different schedule than the CoreScanner, if we wish. 

3) I added error handling to the `UswdsScannerService` so it will actually complete now (even if there's errors!)

The rest of the changes are mostly dependency injection simplification (where I saw it could be refactored) and tests.

Tags: uswds, tests, DI, dependency injection
