### PR TITLE
Add node version for Cloud Foundry

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
+  "engines": {
+    "node": "14.x.x"
+  },
   "scripts": {
     "rmdist": "rimraf dist",
     "build": "nest build",


### PR DESCRIPTION
Why: Need to use LTS (currently 14.x.x) to support the new string methods (`matchAll`).

How: Update the `package.json` to include an `engine` field. 

Tags: cloud foundry, node, version