### PR TITLE
Add USWDS version fields

### DIFF
--- a/entities/solutions-result.entity.ts
+++ b/entities/solutions-result.entity.ts
@@ -77,6 +77,14 @@ export class SolutionsResult {
   uswdsSourceSansFont?: number;
 
   @Column({ nullable: true })
+  @Expose({ name: 'uswds_semantic_version' })
+  uswdsSemanticVersion?: string;
+
+  @Column({ nullable: true })
+  @Expose({ name: 'uswds_version' })
+  uswdsVersion?: number;
+
+  @Column({ nullable: true })
   @Expose({ name: 'uswds_count' })
   uswdsCount?: number;
 }

--- a/libs/solutions-scanner/src/solutions-scanner.service.spec.ts
+++ b/libs/solutions-scanner/src/solutions-scanner.service.spec.ts
@@ -74,6 +74,8 @@ describe('SolutionsScannerService', () => {
     expected.uswdsPublicSansFont = 0; // :TODO mock this
     expected.uswdsSourceSansFont = 0; // :TODO mock this
     expected.uswdsCount = 17;
+    expected.uswdsSemanticVersion = undefined;
+    expected.uswdsVersion = 0;
     expected.status = ScanStatus.Completed;
 
     expect(result).toStrictEqual(expected);

--- a/libs/solutions-scanner/test/app.e2e-spec.ts
+++ b/libs/solutions-scanner/test/app.e2e-spec.ts
@@ -47,7 +47,9 @@ describe('SolutionsScanner (e2e)', () => {
     expected.uswdsMerriweatherFont = 5;
     expected.uswdsPublicSansFont = 20;
     expected.uswdsSourceSansFont = 5;
-    expected.uswdsCount = 121;
+    expected.uswdsSemanticVersion = '2.9.0';
+    expected.uswdsVersion = 20;
+    expected.uswdsCount = 141;
     expected.status = ScanStatus.Completed;
 
     const result = await service.scan(input);


### PR DESCRIPTION
Why: This adds the USWDS version fields to the Solutions scanner. This looks in CSS for the first USWDS version it can find (using RegEx) and returns the version. It also adds 20 points to the USWDS Detection heuristic. 

How: Add fields to the scanner and the data model. Add tests.

Tags: uswds, semantic version, solutions scanner