### PR TITLE
Await page close.

### DIFF
--- a/libs/core-scanner/src/core-scanner.service.ts
+++ b/libs/core-scanner/src/core-scanner.service.ts
@@ -56,7 +56,7 @@ export class CoreScannerService
         this.logger.warn(`Unknown Error calling ${input.url}: ${err.message}`);
       }
     } finally {
-      page.close();
+      await page.close();
       this.logger.debug('closed puppeteer page');
     }
 


### PR DESCRIPTION
Why: Await `page.close` in the core scanner. 