### PR TITLE
Add SSL error and Fix Leaky Test

### DIFF
--- a/libs/browser/src/browser.service.ts
+++ b/libs/browser/src/browser.service.ts
@@ -32,7 +32,9 @@ const BrowserService = {
 function parseBrowserError(err: Error) {
   const dnsError = err.message.startsWith('net::ERR_NAME_NOT_RESOLVED');
   const timeoutError = err.name === 'TimeoutError';
-  const sslError = err.message.startsWith('net::ERR_CERT_COMMON_NAME_INVALID');
+  const sslError =
+    err.message.startsWith('net::ERR_CERT_COMMON_NAME_INVALID') ||
+    err.message.startsWith('unable to verify the first certificate');
 
   let errorType: ScanStatus;
 

--- a/libs/core-scanner/test/app.e2e-spec.ts
+++ b/libs/core-scanner/test/app.e2e-spec.ts
@@ -1,3 +1,4 @@
+import { BrowserService, BROWSER_TOKEN } from '@app/browser';
 import { CoreScannerModule, CoreScannerService } from '@app/core-scanner';
 import { CoreInputDto } from '@app/core-scanner/core.input.dto';
 import { LoggerService } from '@app/logger';
@@ -5,11 +6,13 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { CoreResult } from 'entities/core-result.entity';
 import { Website } from 'entities/website.entity';
 import { noop } from 'lodash';
+import { Browser } from 'puppeteer';
 
 describe('CoreScanner (e2e)', () => {
   let service: CoreScannerService;
   let logger: LoggerService;
   let moduleFixture: TestingModule;
+  let browser: Browser;
 
   beforeEach(async () => {
     moduleFixture = await Test.createTestingModule({
@@ -18,12 +21,13 @@ describe('CoreScanner (e2e)', () => {
 
     service = moduleFixture.get<CoreScannerService>(CoreScannerService);
     logger = moduleFixture.get<LoggerService>(LoggerService);
+    browser = moduleFixture.get<Browser>(BROWSER_TOKEN);
 
     jest.spyOn(logger, 'debug').mockImplementation(noop);
   });
 
   afterAll(async () => {
-    await service.onModuleDestroy();
+    await browser.close();
     await moduleFixture.close();
   });
 


### PR DESCRIPTION
Why: Filling out the SSL errors. Fixed a test that was not tearing down correctly. 

Tags: errors, testing