### PR TITLE
Ignore SSL errors from Axios.

### DIFF
--- a/libs/core-scanner/src/core-scanner.module.ts
+++ b/libs/core-scanner/src/core-scanner.module.ts
@@ -1,11 +1,11 @@
-import { BrowserModule, BrowserService } from '@app/browser';
+import { BrowserModule } from '@app/browser';
 import { LoggerModule } from '@app/logger';
 import { HttpModule, Module } from '@nestjs/common';
 import { CoreScannerService } from './core-scanner.service';
 
 @Module({
   imports: [BrowserModule, LoggerModule, HttpModule],
-  providers: [CoreScannerService, BrowserService],
-  exports: [CoreScannerService, BrowserModule, HttpModule],
+  providers: [CoreScannerService],
+  exports: [CoreScannerService],
 })
 export class CoreScannerModule {}

--- a/libs/core-scanner/test/app.e2e-spec.ts
+++ b/libs/core-scanner/test/app.e2e-spec.ts
@@ -31,7 +31,7 @@ describe('CoreScanner (e2e)', () => {
     await moduleFixture.close();
   });
 
-  it('returns results for a url', async () => {
+  it('returns results for 18f.gov', async () => {
     const input: CoreInputDto = {
       websiteId: 1,
       url: '18f.gov',
@@ -50,6 +50,32 @@ describe('CoreScanner (e2e)', () => {
     expected.status = 'completed';
     expected.targetUrl404Test = true;
     expected.targetUrlBaseDomain = '18f.gov';
+    expected.targetUrlRedirects = true;
+    expected.website = website;
+
+    const result = await service.scan(input);
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('returns results for poolsafety.gov', async () => {
+    const input: CoreInputDto = {
+      websiteId: 1,
+      url: 'poolsafety.gov',
+    };
+    const website = new Website();
+    website.id = input.websiteId;
+
+    const expected = new CoreResult();
+    expected.finalUrl = 'https://www.poolsafely.gov/';
+    expected.finalUrlBaseDomain = 'poolsafely.gov';
+    expected.finalUrlIsLive = true;
+    expected.finalUrlMIMEType = 'text/html';
+    expected.finalUrlSameDomain = false;
+    expected.finalUrlSameWebsite = false;
+    expected.finalUrlStatusCode = 200;
+    expected.status = 'completed';
+    expected.targetUrl404Test = false;
+    expected.targetUrlBaseDomain = 'poolsafety.gov';
     expected.targetUrlRedirects = true;
     expected.website = website;
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
       "json",
       "ts"
     ],
+    "testTimeout": 10000,
     "rootDir": ".",
     "testRegex": ".spec.ts$",
     "transform": {


### PR DESCRIPTION
Why: There is inconsistency in the data, because we are using Axios for the 404 test and Axios throws an SSL error when it can't verify a certificate chain. For now, disable checking that. Add a test for a website that has an incomplete chain. 

Tags: axios, 404 test, testing, SSL, certificate chain