### PR TITLE
Disable the Puppeteer page cache.

### DIFF
--- a/libs/core-scanner/src/core-scanner.service.ts
+++ b/libs/core-scanner/src/core-scanner.service.ts
@@ -36,6 +36,7 @@ export class CoreScannerService
     try {
       // load a page
       page = await this.browser.newPage();
+      await page.setCacheEnabled(false);
 
       // load the url
       this.logger.debug(`loading ${url}`);

--- a/libs/solutions-scanner/src/solutions-scanner.service.ts
+++ b/libs/solutions-scanner/src/solutions-scanner.service.ts
@@ -26,9 +26,9 @@ export class SolutionsScannerService
     try {
       // load the page
       page = await this.browser.newPage();
+      await page.setCacheEnabled(false);
 
       // attach listeners
-
       const cssPages = [];
       page.on('response', async response => {
         if (response.request().resourceType() == 'stylesheet') {


### PR DESCRIPTION
Why: Disables the Puppeteer page cache to avoid 304 status codes. Closes https://github.com/18F/site-scanning/issues/811

Tags: scanning, cache