### PR TITLE
Remove the dev schema drop.

### DIFF
--- a/libs/database/src/database.module.ts
+++ b/libs/database/src/database.module.ts
@@ -20,8 +20,6 @@ const ScannerDatabase = TypeOrmModule.forRootAsync({
       type: 'postgres',
       url: configService.get<string>('database.url'),
       entities: [Website, CoreResult, SolutionsResult],
-      synchronize: true, // do not use this in production
-      dropSchema: true, // do not use this in production
     };
   },
   inject: [ConfigService],


### PR DESCRIPTION
Why: The schema is at a point where dropping the tables and synchronizing is no longer necessary! 🎉 

How: Remove from the database initialization step. 

Tags: DB