### PR TITLE
Add Query Filters to API

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,8 +1,14 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      skipMissingProperties: true,
+    }),
+  );
   await app.listen(process.env.PORT || 3000);
 }
 bootstrap();

--- a/apps/api/src/website/website.controller.spec.ts
+++ b/apps/api/src/website/website.controller.spec.ts
@@ -28,7 +28,7 @@ describe('WebsiteController', () => {
     const coreResult = new CoreResult();
     coreResult.id = 1;
     const solutionsResult = new SolutionsResult();
-    const website = new Website();
+    website = new Website();
     website.coreResult = coreResult;
     website.solutionsResult = solutionsResult;
   });
@@ -39,18 +39,18 @@ describe('WebsiteController', () => {
 
   describe('websites', () => {
     it('should return a list of results', async () => {
-      mockWebsiteService.findAllWithResult
-        .calledWith()
-        .mockResolvedValue([website]);
+      mockWebsiteService.findAllWithResult.mockResolvedValue([website]);
 
-      const result = await websiteController.getResults();
+      const result = await websiteController.getResults({
+        final_url_live: true,
+      });
 
       expect(result).toStrictEqual([website]);
     });
 
     it('should return a result by url', async () => {
       const url = '18f.gov';
-      mockWebsiteService.findByUrl.calledWith(url).mockResolvedValue(website);
+      mockWebsiteService.findByUrl.mockResolvedValue(website);
 
       const result = await websiteController.getResultByUrl(url);
 

--- a/apps/api/src/website/website.controller.ts
+++ b/apps/api/src/website/website.controller.ts
@@ -1,5 +1,6 @@
+import { FilterWebsiteDto } from '@app/database/websites/dto/filter-website.dto';
 import { WebsiteService } from '@app/database/websites/websites.service';
-import { Controller, Get, Param, UseInterceptors } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseInterceptors } from '@nestjs/common';
 import { NotFoundInterceptor } from '../not-found.interceptor';
 import { WebsiteSerializerInterceptor } from './website-serializer.interceptor';
 
@@ -9,8 +10,8 @@ export class WebsiteController {
 
   @Get()
   @UseInterceptors(WebsiteSerializerInterceptor)
-  async getResults() {
-    const websites = await this.websiteService.findAllWithResult();
+  async getResults(@Query() query: FilterWebsiteDto) {
+    const websites = await this.websiteService.findAllWithResult(query);
     return websites;
   }
 

--- a/entities/core-result.entity.ts
+++ b/entities/core-result.entity.ts
@@ -45,7 +45,7 @@ export class CoreResult {
   finalUrl?: string;
 
   @Column({ nullable: true })
-  @Expose({ name: 'final_url_live ' })
+  @Expose({ name: 'final_url_live' })
   finalUrlIsLive?: boolean;
 
   @Column({ nullable: true })

--- a/libs/database/src/websites/dto/filter-website.dto.ts
+++ b/libs/database/src/websites/dto/filter-website.dto.ts
@@ -1,4 +1,5 @@
-import { IsBooleanString, IsUrl } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsBooleanString, IsString, IsUrl } from 'class-validator';
 
 export class FilterWebsiteDto {
   @IsUrl()
@@ -12,4 +13,10 @@ export class FilterWebsiteDto {
 
   @IsBooleanString()
   target_url_redirects?: boolean;
+
+  // @Transform((value: string) => {
+  //   decodeURI(value);
+  // })
+  @IsString()
+  target_url_agency_owner?: string;
 }

--- a/libs/database/src/websites/dto/filter-website.dto.ts
+++ b/libs/database/src/websites/dto/filter-website.dto.ts
@@ -1,4 +1,7 @@
-import { IsBooleanString, IsString, IsUrl } from 'class-validator';
+import { ScanStatus } from '@app/core-scanner/scan-status';
+import { IsBooleanString, IsIn, IsString, IsUrl } from 'class-validator';
+
+const statuses = Object.values(ScanStatus);
 
 export class FilterWebsiteDto {
   @IsUrl()
@@ -18,4 +21,7 @@ export class FilterWebsiteDto {
 
   @IsString()
   target_url_bureau_owner?: string;
+
+  @IsIn(statuses)
+  scan_status?: string;
 }

--- a/libs/database/src/websites/dto/filter-website.dto.ts
+++ b/libs/database/src/websites/dto/filter-website.dto.ts
@@ -24,4 +24,7 @@ export class FilterWebsiteDto {
 
   @IsIn(statuses)
   scan_status?: string;
+
+  @IsBooleanString()
+  dap_detected_final_url?: boolean;
 }

--- a/libs/database/src/websites/dto/filter-website.dto.ts
+++ b/libs/database/src/websites/dto/filter-website.dto.ts
@@ -2,4 +2,5 @@ export class FilterWebsiteDto {
   target_url_domain?: string;
   final_url_domain?: string;
   final_url_live?: boolean;
+  target_url_redirects?: boolean;
 }

--- a/libs/database/src/websites/dto/filter-website.dto.ts
+++ b/libs/database/src/websites/dto/filter-website.dto.ts
@@ -1,3 +1,4 @@
 export class FilterWebsiteDto {
   target_url_domain?: string;
+  final_url_domain?: string;
 }

--- a/libs/database/src/websites/dto/filter-website.dto.ts
+++ b/libs/database/src/websites/dto/filter-website.dto.ts
@@ -1,4 +1,5 @@
 export class FilterWebsiteDto {
   target_url_domain?: string;
   final_url_domain?: string;
+  final_url_live?: boolean;
 }

--- a/libs/database/src/websites/dto/filter-website.dto.ts
+++ b/libs/database/src/websites/dto/filter-website.dto.ts
@@ -1,6 +1,15 @@
+import { IsBooleanString, IsUrl } from 'class-validator';
+
 export class FilterWebsiteDto {
+  @IsUrl()
   target_url_domain?: string;
+
+  @IsUrl()
   final_url_domain?: string;
+
+  @IsBooleanString()
   final_url_live?: boolean;
+
+  @IsBooleanString()
   target_url_redirects?: boolean;
 }

--- a/libs/database/src/websites/dto/filter-website.dto.ts
+++ b/libs/database/src/websites/dto/filter-website.dto.ts
@@ -1,0 +1,3 @@
+export class FilterWebsiteDto {
+  target_url_domain?: string;
+}

--- a/libs/database/src/websites/dto/filter-website.dto.ts
+++ b/libs/database/src/websites/dto/filter-website.dto.ts
@@ -1,4 +1,3 @@
-import { Transform } from 'class-transformer';
 import { IsBooleanString, IsString, IsUrl } from 'class-validator';
 
 export class FilterWebsiteDto {
@@ -14,9 +13,9 @@ export class FilterWebsiteDto {
   @IsBooleanString()
   target_url_redirects?: boolean;
 
-  // @Transform((value: string) => {
-  //   decodeURI(value);
-  // })
   @IsString()
   target_url_agency_owner?: string;
+
+  @IsString()
+  target_url_bureau_owner?: string;
 }

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -46,6 +46,12 @@ export class WebsiteService {
       });
     }
 
+    if (dto.scan_status) {
+      query.andWhere('coreResult.status = :status', {
+        status: dto.scan_status,
+      });
+    }
+
     if (typeof dto.final_url_live != 'undefined') {
       query.andWhere('coreResult.finalUrlIsLive = :finalUrlLive', {
         finalUrlLive: dto.final_url_live,

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -64,6 +64,12 @@ export class WebsiteService {
       });
     }
 
+    if (typeof dto.dap_detected_final_url != 'undefined') {
+      query.andWhere('solutionsResult.dapDetected = :dapDetected', {
+        dapDetected: dto.dap_detected_final_url,
+      });
+    }
+
     return await query.getMany();
   }
 

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -34,13 +34,13 @@ export class WebsiteService {
       });
     }
 
-    if (typeof dto.final_url_live != undefined) {
+    if (typeof dto.final_url_live != 'undefined') {
       query.andWhere('coreResult.finalUrlIsLive = :finalUrlLive', {
         finalUrlLive: dto.final_url_live,
       });
     }
 
-    if (typeof dto.target_url_redirects != undefined) {
+    if (typeof dto.target_url_redirects != 'undefined') {
       query.andWhere('coreResult.targetUrlRedirects = :targetUrlRedirects', {
         targetUrlRedirects: dto.target_url_redirects,
       });

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -40,6 +40,12 @@ export class WebsiteService {
       });
     }
 
+    if (dto.target_url_bureau_owner) {
+      query.andWhere('organization = :organization', {
+        organization: dto.target_url_bureau_owner,
+      });
+    }
+
     if (typeof dto.final_url_live != 'undefined') {
       query.andWhere('coreResult.finalUrlIsLive = :finalUrlLive', {
         finalUrlLive: dto.final_url_live,

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -40,6 +40,12 @@ export class WebsiteService {
       });
     }
 
+    if (typeof dto.target_url_redirects != undefined) {
+      query.andWhere('coreResult.targetUrlRedirects = :targetUrlRedirects', {
+        targetUrlRedirects: dto.target_url_redirects,
+      });
+    }
+
     return await query.getMany();
   }
 

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -34,6 +34,12 @@ export class WebsiteService {
       });
     }
 
+    if (dto.target_url_agency_owner) {
+      query.andWhere('agency = :agency', {
+        agency: dto.target_url_agency_owner,
+      });
+    }
+
     if (typeof dto.final_url_live != 'undefined') {
       query.andWhere('coreResult.finalUrlIsLive = :finalUrlLive', {
         finalUrlLive: dto.final_url_live,

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -22,9 +22,15 @@ export class WebsiteService {
       .leftJoinAndSelect('website.coreResult', 'coreResult')
       .leftJoinAndSelect('website.solutionsResult', 'solutionsResult');
 
-    if (dto.baseDomain) {
-      query.where('coreResult.targetUrlBaseDomain = :baseDomain', {
-        baseDomain: dto.baseDomain,
+    if (dto.target_url_domain) {
+      query.andWhere('coreResult.targetUrlBaseDomain = :baseDomain', {
+        baseDomain: dto.target_url_domain,
+      });
+    }
+
+    if (dto.final_url_domain) {
+      query.andWhere('coreResult.finalUrlBaseDomain = :baseDomain', {
+        baseDomain: dto.final_url_domain,
       });
     }
 

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Website } from 'entities/website.entity';
 import { Repository } from 'typeorm';
 import { CreateWebsiteDto } from './dto/create-website.dto';
+import { FilterWebsiteDto } from './dto/filter-website.dto';
 
 @Injectable()
 export class WebsiteService {
@@ -15,11 +16,19 @@ export class WebsiteService {
     return websites;
   }
 
-  async findAllWithResult(): Promise<Website[]> {
-    const result = await this.website.find({
-      relations: ['coreResult', 'solutionsResult'],
-    });
-    return result;
+  async findAllWithResult(dto: FilterWebsiteDto): Promise<Website[]> {
+    const query = this.website
+      .createQueryBuilder('website')
+      .leftJoinAndSelect('website.coreResult', 'coreResult')
+      .leftJoinAndSelect('website.solutionsResult', 'solutionsResult');
+
+    if (dto.baseDomain) {
+      query.where('coreResult.targetUrlBaseDomain = :baseDomain', {
+        baseDomain: dto.baseDomain,
+      });
+    }
+
+    return await query.getMany();
   }
 
   async findOne(id: number): Promise<Website> {

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -34,6 +34,12 @@ export class WebsiteService {
       });
     }
 
+    if (typeof dto.final_url_live != undefined) {
+      query.andWhere('coreResult.finalUrlIsLive = :finalUrlLive', {
+        finalUrlLive: dto.final_url_live,
+      });
+    }
+
     return await query.getMany();
   }
 


### PR DESCRIPTION
Why: This is query parameters to the API for the following fields: 

- Target URL (path parameter)
- `target_url_domain`
- `final_url_domain`
- `final_url_live`
- `target_url_redirects`
- `target_url_agency_owner`
- `target_url_bureau_owner`
- `scan_status`
- `dap_detected_final_url`

It also adds query parameter validation using the `class-validator` and a `FilterWebsiteDto` data transfer object.

Tags: API, filters, query, validation