### PR TITLE
Add pagination

### DIFF
--- a/apps/api/src/website/website-serializer.interceptor.ts
+++ b/apps/api/src/website/website-serializer.interceptor.ts
@@ -23,10 +23,11 @@ export class WebsiteSerializerInterceptor implements NestInterceptor {
             return serialized;
           });
 
-          const apiResult = {
+          const apiResult = new Pagination(
             serializedItems,
-            ...result,
-          };
+            result.meta,
+            result.links,
+          );
 
           return apiResult;
         }

--- a/apps/api/src/website/website-serializer.interceptor.ts
+++ b/apps/api/src/website/website-serializer.interceptor.ts
@@ -23,11 +23,10 @@ export class WebsiteSerializerInterceptor implements NestInterceptor {
             return serialized;
           });
 
-          const apiResult = new Pagination(
+          const apiResult = {
             serializedItems,
-            result.meta,
-            result.links,
-          );
+            ...result,
+          };
 
           return apiResult;
         }

--- a/apps/api/src/website/website.controller.spec.ts
+++ b/apps/api/src/website/website.controller.spec.ts
@@ -5,11 +5,13 @@ import { WebsiteController } from './website.controller';
 import { CoreResult } from 'entities/core-result.entity';
 import { SolutionsResult } from 'entities/solutions-result.entity';
 import { Website } from 'entities/website.entity';
+import { Pagination } from 'nestjs-typeorm-paginate';
 
 describe('WebsiteController', () => {
   let websiteController: WebsiteController;
   let mockWebsiteService: MockProxy<WebsiteService>;
   let website: Website;
+  let paginated: Pagination<Website>;
 
   beforeEach(async () => {
     mockWebsiteService = mock<WebsiteService>();
@@ -31,6 +33,13 @@ describe('WebsiteController', () => {
     website = new Website();
     website.coreResult = coreResult;
     website.solutionsResult = solutionsResult;
+    paginated = new Pagination([website], {
+      itemCount: 10,
+      currentPage: 1,
+      totalItems: 100,
+      totalPages: 10,
+      itemsPerPage: 10,
+    });
   });
 
   afterEach(async () => {
@@ -39,13 +48,13 @@ describe('WebsiteController', () => {
 
   describe('websites', () => {
     it('should return a list of results', async () => {
-      mockWebsiteService.findAllWithResult.mockResolvedValue([website]);
+      mockWebsiteService.paginatedFilter.mockResolvedValue(paginated);
 
       const result = await websiteController.getResults({
         final_url_live: true,
       });
 
-      expect(result).toStrictEqual([website]);
+      expect(result).toStrictEqual(paginated);
     });
 
     it('should return a result by url', async () => {

--- a/apps/api/src/website/website.controller.ts
+++ b/apps/api/src/website/website.controller.ts
@@ -10,8 +10,16 @@ export class WebsiteController {
 
   @Get()
   @UseInterceptors(WebsiteSerializerInterceptor)
-  async getResults(@Query() query: FilterWebsiteDto) {
-    const websites = await this.websiteService.findAllWithResult(query);
+  async getResults(
+    @Query() query: FilterWebsiteDto,
+    @Query('page') page = 1,
+    @Query('limit') limit = 10,
+  ) {
+    const websites = await this.websiteService.paginatedFilter(query, {
+      page: page,
+      limit: limit,
+      route: 'http://localhost:3000',
+    });
     return websites;
   }
 
@@ -21,7 +29,7 @@ export class WebsiteController {
     WebsiteSerializerInterceptor,
   )
   async getResultByUrl(@Param('url') url: string) {
-    const result = await this.websiteService.findByUrl(url.toUpperCase());
+    const result = await this.websiteService.findByUrl(url);
     return result;
   }
 }

--- a/apps/api/src/website/website.controller.ts
+++ b/apps/api/src/website/website.controller.ts
@@ -1,10 +1,19 @@
 import { FilterWebsiteDto } from '@app/database/websites/dto/filter-website.dto';
 import { WebsiteService } from '@app/database/websites/websites.service';
-import { Controller, Get, Param, Query, UseInterceptors } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Query,
+  UseInterceptors,
+} from '@nestjs/common';
 import { NotFoundInterceptor } from '../not-found.interceptor';
 import { WebsiteSerializerInterceptor } from './website-serializer.interceptor';
 
-@Controller('websites')
+const WEBSITE_ROUTE_NAME = 'websites';
+
+@Controller(WEBSITE_ROUTE_NAME)
 export class WebsiteController {
   constructor(private readonly websiteService: WebsiteService) {}
 
@@ -12,13 +21,13 @@ export class WebsiteController {
   @UseInterceptors(WebsiteSerializerInterceptor)
   async getResults(
     @Query() query: FilterWebsiteDto,
-    @Query('page') page = 1,
-    @Query('limit') limit = 10,
+    @Query('page', ParseIntPipe) page = 1,
+    @Query('limit', ParseIntPipe) limit = 10,
   ) {
     const websites = await this.websiteService.paginatedFilter(query, {
       page: page,
       limit: limit,
-      route: 'http://localhost:3000',
+      route: `/${WEBSITE_ROUTE_NAME}`,
     });
     return websites;
   }

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -4,6 +4,11 @@ import { Website } from 'entities/website.entity';
 import { Repository } from 'typeorm';
 import { CreateWebsiteDto } from './dto/create-website.dto';
 import { FilterWebsiteDto } from './dto/filter-website.dto';
+import {
+  IPaginationOptions,
+  paginate,
+  Pagination,
+} from 'nestjs-typeorm-paginate';
 
 @Injectable()
 export class WebsiteService {
@@ -16,7 +21,10 @@ export class WebsiteService {
     return websites;
   }
 
-  async findAllWithResult(dto: FilterWebsiteDto): Promise<Website[]> {
+  async paginatedFilter(
+    dto: FilterWebsiteDto,
+    options: IPaginationOptions,
+  ): Promise<Pagination<Website>> {
     const query = this.website
       .createQueryBuilder('website')
       .leftJoinAndSelect('website.coreResult', 'coreResult')
@@ -70,7 +78,9 @@ export class WebsiteService {
       });
     }
 
-    return await query.getMany();
+    query.orderBy('website.url', 'DESC');
+
+    return await paginate(query, options);
   }
 
   async findOne(id: number): Promise<Website> {
@@ -79,10 +89,11 @@ export class WebsiteService {
   }
 
   async findByUrl(url: string): Promise<Website> {
+    const upperUrl = url.toUpperCase();
     const result = await this.website.findOne({
       relations: ['coreResult', 'solutionsResult'],
       where: {
-        url: url,
+        url: upperUrl,
       },
     });
     return result;

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,8 +9,6 @@ applications:
   instances: 1
   random-route: true
   command: npm run start:prod:api
-  env:
-    API_ROUTE: https://api.gsa.gov/technology/site-scanning/v1/
 
 
 - name: site-scanner-producer

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,6 +9,9 @@ applications:
   instances: 1
   random-route: true
   command: npm run start:prod:api
+  env:
+    API_ROUTE: https://api.gsa.gov/technology/site-scanning/v1/
+
 
 - name: site-scanner-producer
   disk_quota: 4096M

--- a/package-lock.json
+++ b/package-lock.json
@@ -9802,6 +9802,12 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "nestjs-typeorm-paginate": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/nestjs-typeorm-paginate/-/nestjs-typeorm-paginate-2.2.6.tgz",
+      "integrity": "sha512-Tm/3fyjfy5j/deTwunWXg5sNKWjZVmTonygdd2A2sgYOr92ItvGiQGmujPgVQDOvW5kVVu/4QxfecHeOOQ/DIA==",
+      "dev": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "jest": "26.4.2",
     "jest-mock-extended": "^1.0.10",
     "mermaid": "^8.8.3",
+    "nestjs-typeorm-paginate": "^2.2.6",
     "prettier": "^1.19.1",
     "rimraf": "^3.0.2",
     "supertest": "^4.0.2",


### PR DESCRIPTION
Why: This adds pagination to the API using the `nestjs-typeorm-paginate` library. A few updates had to be made to the Websites serializer as well in order to accommodate the pagination. 

Tags: pagination, nestjs, typeorm