### PR TITLE
Add paginate library to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9805,8 +9805,7 @@
     "nestjs-typeorm-paginate": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/nestjs-typeorm-paginate/-/nestjs-typeorm-paginate-2.2.6.tgz",
-      "integrity": "sha512-Tm/3fyjfy5j/deTwunWXg5sNKWjZVmTonygdd2A2sgYOr92ItvGiQGmujPgVQDOvW5kVVu/4QxfecHeOOQ/DIA==",
-      "dev": true
+      "integrity": "sha512-Tm/3fyjfy5j/deTwunWXg5sNKWjZVmTonygdd2A2sgYOr92ItvGiQGmujPgVQDOvW5kVVu/4QxfecHeOOQ/DIA=="
     },
     "nice-try": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^6.5.4",
     "typeorm": "^0.2.29",
+    "nestjs-typeorm-paginate": "^2.2.6",
     "uuid": "^8.3.1"
   },
   "devDependencies": {
@@ -76,7 +77,6 @@
     "jest": "26.4.2",
     "jest-mock-extended": "^1.0.10",
     "mermaid": "^8.8.3",
-    "nestjs-typeorm-paginate": "^2.2.6",
     "prettier": "^1.19.1",
     "rimraf": "^3.0.2",
     "supertest": "^4.0.2",


### PR DESCRIPTION
Why: Fix that adds paginate library to dependencies and removes from devDependencies.