### PR TITLE
Fix pagination bug

### DIFF
--- a/apps/api/src/parse-optional-int.pipe.spec.ts
+++ b/apps/api/src/parse-optional-int.pipe.spec.ts
@@ -1,0 +1,35 @@
+import { ParseOptionalIntPipe } from './parse-optional-int.pipe';
+
+describe('ParseOptionalIntPipe', () => {
+  let pipe: ParseOptionalIntPipe;
+
+  beforeEach(() => {
+    pipe = new ParseOptionalIntPipe();
+  });
+
+  it('should be defined', () => {
+    expect(pipe).toBeDefined();
+  });
+
+  it('should do nothing for undefined values', () => {
+    const result = pipe.transform(undefined, {
+      type: 'query',
+    });
+    expect(result).toStrictEqual(undefined);
+  });
+
+  it('should parse number strings', () => {
+    const result = pipe.transform('10', {
+      type: 'query',
+    });
+    expect(result).toStrictEqual(10);
+  });
+
+  it('should throw a BadRequestException when value is NaN', () => {
+    expect(() => {
+      pipe.transform('abc', {
+        type: 'query',
+      });
+    }).toThrow('Expected an integer value');
+  });
+});

--- a/apps/api/src/parse-optional-int.pipe.ts
+++ b/apps/api/src/parse-optional-int.pipe.ts
@@ -1,0 +1,19 @@
+import {
+  ArgumentMetadata,
+  BadRequestException,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
+
+@Injectable()
+export class ParseOptionalIntPipe implements PipeTransform {
+  transform(value: any, metadata: ArgumentMetadata) {
+    if (value) {
+      const parsed = parseInt(value, 10);
+      if (isNaN(parsed)) {
+        throw new BadRequestException('Expected an integer value');
+      }
+      return parsed;
+    }
+  }
+}

--- a/apps/api/src/website/website.controller.ts
+++ b/apps/api/src/website/website.controller.ts
@@ -19,8 +19,8 @@ export class WebsiteController {
     @Query('limit', ParseOptionalIntPipe) limit = 10,
   ) {
     const websites = await this.websiteService.paginatedFilter(query, {
-      page: page || 1,
-      limit: limit || 10,
+      page: page,
+      limit: limit,
       route: `/${WEBSITE_ROUTE_NAME}`,
     });
     return websites;

--- a/apps/api/src/website/website.controller.ts
+++ b/apps/api/src/website/website.controller.ts
@@ -1,14 +1,8 @@
 import { FilterWebsiteDto } from '@app/database/websites/dto/filter-website.dto';
 import { WebsiteService } from '@app/database/websites/websites.service';
-import {
-  Controller,
-  Get,
-  Param,
-  ParseIntPipe,
-  Query,
-  UseInterceptors,
-} from '@nestjs/common';
+import { Controller, Get, Param, Query, UseInterceptors } from '@nestjs/common';
 import { NotFoundInterceptor } from '../not-found.interceptor';
+import { ParseOptionalIntPipe } from '../parse-optional-int.pipe';
 import { WebsiteSerializerInterceptor } from './website-serializer.interceptor';
 
 const WEBSITE_ROUTE_NAME = 'websites';
@@ -21,12 +15,12 @@ export class WebsiteController {
   @UseInterceptors(WebsiteSerializerInterceptor)
   async getResults(
     @Query() query: FilterWebsiteDto,
-    @Query('page', ParseIntPipe) page = 1,
-    @Query('limit', ParseIntPipe) limit = 10,
+    @Query('page', ParseOptionalIntPipe) page = 1,
+    @Query('limit', ParseOptionalIntPipe) limit = 10,
   ) {
     const websites = await this.websiteService.paginatedFilter(query, {
-      page: page,
-      limit: limit,
+      page: page || 1,
+      limit: limit || 10,
       route: `/${WEBSITE_ROUTE_NAME}`,
     });
     return websites;


### PR DESCRIPTION
Why: Fix pagination issue by adding a new `Pipe` that parses ints and ignores `undefined`. Add tests.

Tags: Pagination, pipes, tests