### PR TITLE
Bump up memory and instances for consumer and producer

### DIFF
--- a/apps/scan-engine/src/scan-engine.consumer.ts
+++ b/apps/scan-engine/src/scan-engine.consumer.ts
@@ -41,7 +41,7 @@ export class ScanEngineConsumer {
    */
   @Process({
     name: CORE_SCAN_JOB_NAME,
-    concurrency: 10,
+    concurrency: 6,
   })
   async processCore(job: Job<CoreInputDto>) {
     this.logger.debug(`scanning ${job.data.url}`);

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ applications:
   timeout: 10 # seconds
   services:
     - scanner-postgres
-  memory: 500M
+  memory: 2048M
   instances: 1
   random-route: true
   command: npm run start:prod:api
@@ -16,7 +16,7 @@ applications:
   services:
     - scanner-postgres
     - scanner-message-queue
-  memory: 500M
+  memory: 2048M
   instances: 1
   no-route: true
   command: npm run start:prod:producer
@@ -34,7 +34,7 @@ applications:
   buildpacks:
     - https://github.com/cloudfoundry/apt-buildpack/
     - https://github.com/cloudfoundry/nodejs-buildpack/
-  instances: 2
+  instances: 3
   no-route: true
   command: npm run start:prod:scan-engine
   health-check-type: process


### PR DESCRIPTION
Why: This is mostly some tuning after observing behavior in Cloud.gov for a bit. This bumps up the memory for the producer (which was experiencing Exit Code 137 on start) and the API. It also increases the instance number on the consumers and lowers the concurrency in the the individual processes.

How: Update the `ScanEngineConsumer` and the `manifest.yml` files. 

Tags: Infrastructure, tuning, performance, bugfix