### PR TITLE
Switch to AWS Managed Redis.

### DIFF
--- a/deploy-cloudgov.sh
+++ b/deploy-cloudgov.sh
@@ -57,7 +57,7 @@ wait_until_created()
 SCANNER_POSTGRES_NAME="scanner-postgres"
 SCANNER_POSTGRES_PLAN="micro-psql"
 SCANNER_MESSAGE_QUEUE_NAME="scanner-message-queue"
-SCANNER_MESSAGE_QUEUE_PLAN="standard"
+SCANNER_MESSAGE_QUEUE_PLAN="redis-3node"
 
 
 if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
@@ -76,7 +76,7 @@ if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
   if service_exists "$SCANNER_MESSAGE_QUEUE_NAME" ; then
     already_exists "$SCANNER_MESSAGE_QUEUE_NAME"
   else
-    cf create-service redis32 $SCANNER_MESSAGE_QUEUE_PLAN $SCANNER_MESSAGE_QUEUE_NAME
+    cf create-service aws-elasticache-redis $SCANNER_MESSAGE_QUEUE_PLAN $SCANNER_MESSAGE_QUEUE_NAME
   fi
 
   wait_until_created $SCANNER_POSTGRES_NAME

--- a/libs/message-queue/src/config/mq.config.ts
+++ b/libs/message-queue/src/config/mq.config.ts
@@ -5,7 +5,7 @@
 export default () => {
   if (process.env.VCAP_SERVICES) {
     const vcap = JSON.parse(process.env.VCAP_SERVICES);
-    const redis = vcap['redis32'][0];
+    const redis = vcap['aws-elasticache-redis'][0];
     return {
       redis: {
         host: redis.credentials.hostname,


### PR DESCRIPTION
Why: Cloud.gov is deprecating the Kubernetes-backed Redis and switching to AWS Elasticache Managed Redis. This updates to our version to the AWS Managed service. 

Tags: redis, elasticache, aws, cloud.gov

Closes https://github.com/18F/site-scanning/issues/801