### PR TITLE
Bugfix: Redis connections hanging

### DIFF
--- a/libs/message-queue/src/message-queue.module.ts
+++ b/libs/message-queue/src/message-queue.module.ts
@@ -19,6 +19,7 @@ const ScannerQueue = BullModule.registerQueueAsync({
       host: configService.get('redis.host'),
       port: +configService.get<number>('redis.port'),
       password: configService.get('redis.password'),
+      tls: {},
     },
   }),
   inject: [ConfigService],


### PR DESCRIPTION
Why: After switching to AWS-Managed Elasticache Redis, all attempts to connect started hanging. The `BullModule` which we use for message queue management, uses `ioredis` behind the scenes to interface with Redis. 

Following the advice from [this GitHub Issue comment](https://github.com/luin/ioredis/issues/1042#issuecomment-575642093), fixed the connection issues.

Tags: redis, bugfix, tls, config, bull, elasticache, cloud.gov, 

