### PR TITLE
Local Dev Bugfixes: start:all concurrency and message queue configuration

### DIFF
--- a/libs/message-queue/src/config/mq.config.ts
+++ b/libs/message-queue/src/config/mq.config.ts
@@ -11,6 +11,7 @@ export default () => {
         host: redis.credentials.hostname,
         port: redis.credentials.port,
         password: redis.credentials.password,
+        tls: {},
       },
     };
   } else {
@@ -19,6 +20,7 @@ export default () => {
         host: process.env.QUEUE_HOST,
         port: process.env.QUEUE_PORT,
         password: process.env.QUEUE_PASSWORD,
+        tls: undefined,
       },
     };
   }

--- a/libs/message-queue/src/message-queue.module.ts
+++ b/libs/message-queue/src/message-queue.module.ts
@@ -19,7 +19,7 @@ const ScannerQueue = BullModule.registerQueueAsync({
       host: configService.get('redis.host'),
       port: +configService.get<number>('redis.port'),
       password: configService.get('redis.password'),
-      tls: {},
+      tls: configService.get('tls'),
     },
   }),
   inject: [ConfigService],

--- a/package-lock.json
+++ b/package-lock.json
@@ -504,6 +504,21 @@
         }
       }
     },
+    "@hapi/hoek": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
+      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==",
+      "dev": true
+    },
+    "@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1734,6 +1749,27 @@
         "@angular-devkit/core": "11.0.1",
         "@angular-devkit/schematics": "11.0.1"
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
+      "integrity": "sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+      "dev": true
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.8.1",
@@ -8960,6 +8996,19 @@
         }
       }
     },
+    "joi": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.3.0.tgz",
+      "integrity": "sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12751,6 +12800,48 @@
       "dev": true,
       "requires": {
         "xml-name-validator": "^3.0.0"
+      }
+    },
+    "wait-on": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-5.2.0.tgz",
+      "integrity": "sha512-U1D9PBgGw2XFc6iZqn45VBubw02VsLwnZWteQ1au4hUVHasTZuFSKRzlTB2dqgLhji16YVI8fgpEpwUdCr8B6g==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.19.2",
+        "joi": "^17.1.1",
+        "lodash": "^4.17.19",
+        "minimist": "^1.2.5",
+        "rxjs": "^6.5.5"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.19.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "1.5.10"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "dev": true,
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        }
       }
     },
     "walker": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "rmdist": "rimraf dist",
     "build": "nest build",
+    "build:all": "nest build api && nest build producer && nest build scan-engine",
     "format": "prettier --write \"apps/**/*.ts\" \"libs/**/*.ts\"",
     "ingest": "nest start cli -- ingest",
     "start": "nest start",
@@ -18,11 +19,13 @@
     "start:debug": "nest start --debug --watch",
     "start:api": "nest start api",
     "start:producer": "nest start producer",
-    "start:scanner": "nest start scanner",
+    "start:scan-engine": "nest start scan-engine",
     "start:prod:api": "node dist/apps/api/main.js",
     "start:prod:producer": "node dist/apps/producer/main.js",
     "start:prod:scan-engine": "node dist/apps/scan-engine/main.js",
-    "start:all": "concurrently \"npm run start producer\" \"npm run start scan-engine\" \"npm run start api\"",
+    "start:concurrent-producer": "wait-on http://localhost:3000 && nest start producer",
+    "start:concurrent-scan-engine": "wait-on http://localhost:3000 && nest start scan-engine",
+    "start:all": "concurrently \"npm run start:api\" \"npm run start:concurrent-producer\" \"npm run start:concurrent-scan-engine\"",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:unit": "jest --testPathIgnorePatterns ./{apps,libs}/**/test/*",
@@ -84,7 +87,8 @@
     "ts-loader": "^6.2.1",
     "ts-node": "9.0.0",
     "tsconfig-paths": "^3.9.0",
-    "typescript": "^3.7.4"
+    "typescript": "^3.7.4",
+    "wait-on": "^5.2.0"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
Why: This fixes the `start:all` issue in which races between the processes using `concurrently` would create some noise on start up. It also fixes an issue with the local development of the message queue, namely that connections to Redis were failing during local development. 

Tags: bugfix, message queue, concurrently, local development