### PR TITLE
Fix scan date issue.

### DIFF
--- a/entities/core-result.entity.ts
+++ b/entities/core-result.entity.ts
@@ -20,7 +20,9 @@ export class CoreResult {
   @Exclude({ toPlainOnly: true })
   created: string;
 
-  @UpdateDateColumn()
+  @UpdateDateColumn({
+    type: "timestamptz"
+  })
   @Expose({ name: 'scan_date' })
   updated: string;
 


### PR DESCRIPTION
Why: `scan_date` was not updating. This fixes the column to populate on updates. 

Closes https://github.com/18F/site-scanning/issues/830