### PR TITLE
Set cron schedule to midnight.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -22,7 +22,7 @@ applications:
   command: npm run start:prod:producer
   health-check-type: process
   env:
-    CORE_SCAN_SCHEDULE: "25 * * * *"
+    CORE_SCAN_SCHEDULE: "0 0 * * *"
 
 
 - name: site-scanner-consumer


### PR DESCRIPTION
Why: This sets the scanners to run at 00:00 server time. 

Tags: cron, scanners