### PR TITLE
Fix Date Issue: Pt. 2

### DIFF
--- a/entities/core-result.entity.ts
+++ b/entities/core-result.entity.ts
@@ -20,16 +20,11 @@ export class CoreResult {
   @Exclude({ toPlainOnly: true })
   created: string;
 
-  @UpdateDateColumn({
-    type: "timestamptz"
-  })
+  @UpdateDateColumn()
   @Expose({ name: 'scan_date' })
   updated: string;
 
-  @OneToOne(
-    () => Website,
-    website => website.coreResult,
-  )
+  @OneToOne(() => Website, (website) => website.coreResult)
   @JoinColumn()
   @Exclude({ toPlainOnly: true })
   website: Website;

--- a/libs/database/src/core-results/core-result.module.ts
+++ b/libs/database/src/core-results/core-result.module.ts
@@ -1,10 +1,11 @@
+import { LoggerModule } from '@app/logger';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CoreResult } from 'entities/core-result.entity';
 import { CoreResultService } from './core-result.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([CoreResult])],
+  imports: [TypeOrmModule.forFeature([CoreResult]), LoggerModule],
   providers: [CoreResultService],
   exports: [TypeOrmModule, CoreResultService],
 })

--- a/libs/database/src/core-results/core-result.service.spec.ts
+++ b/libs/database/src/core-results/core-result.service.spec.ts
@@ -1,3 +1,4 @@
+import { LoggerService } from '@app/logger';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { CoreResult } from 'entities/core-result.entity';
@@ -9,15 +10,21 @@ import { CoreResultService } from './core-result.service';
 describe('CoreResultService', () => {
   let service: CoreResultService;
   let mockRepository: MockProxy<Repository<CoreResult>>;
+  let mockLogger: MockProxy<LoggerService>;
 
   beforeEach(async () => {
     mockRepository = mock<Repository<CoreResult>>();
+    mockLogger = mock<LoggerService>();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CoreResultService,
         {
           provide: getRepositoryToken(CoreResult),
           useValue: mockRepository,
+        },
+        {
+          provide: LoggerService,
+          useValue: mockLogger,
         },
       ],
     }).compile();
@@ -65,6 +72,6 @@ describe('CoreResultService', () => {
     coreResult.website = website;
 
     await service.create(coreResult);
-    expect(mockRepository.save).toHaveBeenCalledWith(coreResult);
+    expect(mockRepository.insert).toHaveBeenCalledWith(coreResult);
   });
 });

--- a/libs/database/src/core-results/core-result.service.ts
+++ b/libs/database/src/core-results/core-result.service.ts
@@ -1,12 +1,14 @@
+import { LoggerService } from '@app/logger';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CoreResult } from 'entities/core-result.entity';
-import { Repository } from 'typeorm';
+import { Repository, SaveOptions } from 'typeorm';
 
 @Injectable()
 export class CoreResultService {
   constructor(
     @InjectRepository(CoreResult) private coreResult: Repository<CoreResult>,
+    private logger: LoggerService,
   ) {}
 
   async findAll(): Promise<CoreResult[]> {
@@ -35,15 +37,10 @@ export class CoreResultService {
         },
       },
     });
-
     if (exists) {
-      // then update
-      await this.coreResult.save({
-        ...exists,
-        ...coreResult,
-      });
+      await this.coreResult.update(exists.id, coreResult);
     } else {
-      await this.coreResult.save(coreResult);
+      await this.coreResult.insert(coreResult);
     }
   }
 }

--- a/libs/database/src/core-results/core-result.service.ts
+++ b/libs/database/src/core-results/core-result.service.ts
@@ -2,7 +2,7 @@ import { LoggerService } from '@app/logger';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CoreResult } from 'entities/core-result.entity';
-import { Repository, SaveOptions } from 'typeorm';
+import { Repository } from 'typeorm';
 
 @Injectable()
 export class CoreResultService {

--- a/libs/database/src/solutions-results/solutions-result.service.spec.ts
+++ b/libs/database/src/solutions-results/solutions-result.service.spec.ts
@@ -57,6 +57,6 @@ describe('SolutionsResultService', () => {
     solutionsResult.website = website;
 
     await service.create(solutionsResult);
-    expect(mockRespository.save).toHaveBeenCalledWith(solutionsResult);
+    expect(mockRespository.insert).toHaveBeenCalledWith(solutionsResult);
   });
 });

--- a/libs/database/src/solutions-results/solutions-result.service.ts
+++ b/libs/database/src/solutions-results/solutions-result.service.ts
@@ -31,12 +31,9 @@ export class SolutionsResultService {
 
     if (exists) {
       // then update
-      await this.solutionsResult.save({
-        ...exists,
-        ...solutionsResult,
-      });
+      await this.solutionsResult.update(exists.id, solutionsResult);
     } else {
-      await this.solutionsResult.save(solutionsResult);
+      await this.solutionsResult.insert(solutionsResult);
     }
   }
 }


### PR DESCRIPTION
Why: There was a bug in the way I was saving both `CoreResult`s and `SolutionsResult`s. This basically meant that the original `updated` date would always be persisted on updates to the database. This change uses the `insert` and `update` methods of the Typeorm repository so that the existing object is updated (or the new object is created). 

How: Change the `core-results-service` and `solutions-results-service`. Update the tests.

Tags: bugfix, typeorm, updated, core-result, solutions-result