### PR TITLE
Add Bulk Download Feature

### DIFF
--- a/apps/api/src/website/website-serializer.interceptor.ts
+++ b/apps/api/src/website/website-serializer.interceptor.ts
@@ -4,7 +4,6 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
-import { classToPlain } from 'class-transformer';
 import { Website } from 'entities/website.entity';
 import { Pagination } from 'nestjs-typeorm-paginate';
 import { Observable } from 'rxjs';
@@ -16,10 +15,10 @@ export class WebsiteSerializerInterceptor implements NestInterceptor {
     return next.handle().pipe(
       map((result: Website | Pagination<Website>) => {
         if (result instanceof Website) {
-          return this.serializer(result);
+          return result.serialized();
         } else {
-          const serializedItems = result.items.map(website => {
-            const serialized = this.serializer(website);
+          const serializedItems = result.items.map((website) => {
+            const serialized = website.serialized();
             return serialized;
           });
 
@@ -33,17 +32,5 @@ export class WebsiteSerializerInterceptor implements NestInterceptor {
         }
       }),
     );
-  }
-
-  private serializer(website: Website) {
-    const serializedWebsite = classToPlain(website);
-    const serializedCoreResult = classToPlain(website.coreResult);
-    const serializedSolutionsResult = classToPlain(website.solutionsResult);
-
-    return {
-      ...serializedCoreResult,
-      ...serializedSolutionsResult,
-      ...serializedWebsite,
-    };
   }
 }

--- a/apps/producer/src/producer.module.ts
+++ b/apps/producer/src/producer.module.ts
@@ -1,6 +1,7 @@
 import { DatabaseModule } from '@app/database';
 import { WebsiteService } from '@app/database/websites/websites.service';
 import { MessageQueueModule } from '@app/message-queue';
+import { SnapshotModule } from '@app/snapshot';
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
@@ -14,6 +15,7 @@ import { TaskService } from './task/task.service';
     MessageQueueModule,
     ConfigModule.forRoot(),
     ScheduleModule.forRoot(),
+    SnapshotModule,
     LoggerModule,
   ],
   providers: [

--- a/apps/producer/src/task/task.service.spec.ts
+++ b/apps/producer/src/task/task.service.spec.ts
@@ -8,17 +8,20 @@ import { mock, mockReset, MockProxy } from 'jest-mock-extended';
 import { ProducerService } from '../producer/producer.service';
 import { TaskService } from './task.service';
 import { Website } from 'entities/website.entity';
+import { SnapshotService } from '@app/snapshot';
 
 describe('TaskService', () => {
   let service: TaskService;
   let producerMock: MockProxy<ProducerService>;
   let websiteServiceMock: MockProxy<WebsiteService>;
   let loggerMock: MockProxy<LoggerService>;
+  let snapshotMock: MockProxy<SnapshotService>;
 
   beforeEach(async () => {
     producerMock = mock<ProducerService>();
     websiteServiceMock = mock<WebsiteService>();
     loggerMock = mock<LoggerService>();
+    snapshotMock = mock<SnapshotService>();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TaskService,
@@ -42,14 +45,14 @@ describe('TaskService', () => {
           provide: SchedulerRegistry,
           useValue: {},
         },
+        {
+          provide: SnapshotService,
+          useValue: snapshotMock,
+        },
       ],
     }).compile();
 
     service = module.get<TaskService>(TaskService);
-  });
-
-  afterEach(async () => {
-    mockReset(producerMock);
   });
 
   it('should be defined', () => {
@@ -69,5 +72,10 @@ describe('TaskService', () => {
     };
     await service.coreScanProducer();
     expect(producerMock.addCoreJob).toBeCalledWith(expected);
+  });
+
+  it('should create snapshot jobs', async () => {
+    await service.snapshot();
+    expect(snapshotMock.weeklySnapshot).toHaveBeenCalled();
   });
 });

--- a/apps/producer/src/task/task.service.ts
+++ b/apps/producer/src/task/task.service.ts
@@ -68,9 +68,7 @@ export class TaskService {
 
   async snapshot() {
     try {
-      this.snapshotService.save({
-        name: 'weekly-snapshot.json',
-      });
+      this.snapshotService.weeklySnapshot();
     } catch (error) {
       const err = error as Error;
       this.logger.error(err.message, err.stack);

--- a/apps/producer/src/task/task.service.ts
+++ b/apps/producer/src/task/task.service.ts
@@ -26,15 +26,19 @@ export class TaskService {
     await this.producerService.emptyAndClean();
     this.logger.debug('producer queue emptied.');
 
-    const schedule =
+    const scanSchedule =
       this.configService.get<string>('CORE_SCAN_SCHEDULE') || '0 0 * * *';
-    this.logger.debug(`using schedule ${schedule}`);
+    this.logger.debug(`core scan schedule ${scanSchedule}`);
 
-    const coreJob = new CronJob(schedule, async () => {
+    const snapshotSchedule =
+      this.configService.get<string>('SNAPSHOT_SCHEDULE') || '0 0 * * *';
+    this.logger.debug(`snapshot schedule ${snapshotSchedule}`);
+
+    const coreJob = new CronJob(scanSchedule, async () => {
       await this.coreScanProducer();
     });
 
-    const snapshotJob = new CronJob(schedule, async () => {
+    const snapshotJob = new CronJob(snapshotSchedule, async () => {
       await this.snapshot();
     });
 

--- a/deploy-cloudgov.sh
+++ b/deploy-cloudgov.sh
@@ -27,7 +27,7 @@ cleanup() {
 service_exists()
 {
   info "checking if ${1} exists..."
-  cf service "$1" >/dev/null 2>&1
+  cf service "$1" > /dev/null 2>&1
 }
 
 service_status()
@@ -58,6 +58,8 @@ SCANNER_POSTGRES_NAME="scanner-postgres"
 SCANNER_POSTGRES_PLAN="micro-psql"
 SCANNER_MESSAGE_QUEUE_NAME="scanner-message-queue"
 SCANNER_MESSAGE_QUEUE_PLAN="redis-3node"
+SCANNER_PUBLIC_STORAGE_NAME="scanner-public-storage"
+SCANNER_PUBLIC_STORAGE_PLAN="basic-public"
 
 
 if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
@@ -79,6 +81,13 @@ if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
   else
     cf create-service aws-elasticache-redis $SCANNER_MESSAGE_QUEUE_PLAN $SCANNER_MESSAGE_QUEUE_NAME
     wait_until_created $SCANNER_MESSAGE_QUEUE_NAME
+  fi
+
+  if service_exists "$SCANNER_PUBLIC_STORAGE_NAME"; then
+    already_exists "$SCANNER_PUBLIC_STORAGE_NAME"
+  else
+    cf create-service s3 $SCANNER_PUBLIC_STORAGE_PLAN $SCANNER_PUBLIC_STORAGE_NAME
+    wait_until_created $SCANNER_PUBLIC_STORAGE_NAME
   fi
 
   # next, compile the typescript for all of the apps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         container_name: minio
         image: minio/minio
         volumes:
-            - ./storage/:/storage
+            - $TMPDIR/storage/:/storage
         env_file: 
             - .env
         command: server /storage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,17 @@ services:
         networks:
             - webnet
 
+    s3:
+        container_name: s3
+        image: minio/minio
+        command: server /data
+        ports:
+            - "9000:9000"
+        env_file:
+            - .env
+        networks:
+            - webnet
+
 networks:
     webnet:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-# using this https://blog.logrocket.com/containerized-development-nestjs-docker/
-# for inspiration
 version: "3.8"
 services:
     postgres:
@@ -20,16 +18,30 @@ services:
         networks:
             - webnet
 
-    s3:
-        container_name: s3
+    storage:
+        container_name: minio
         image: minio/minio
-        command: server /site-scanning-snapshot
+        volumes:
+            - ./storage/:/storage
+        env_file: 
+            - .env
+        command: server /storage
         ports:
             - "9000:9000"
-        env_file:
+
+    createbuckets:
+        image: minio/mc
+        depends_on:
+            - storage
+        env_file: 
             - .env
-        networks:
-            - webnet
+        entrypoint: >
+            /bin/sh -c "
+            until (/usr/bin/mc config host add myminio http://storage:9000 \$MINIO_ACCESS_KEY \$MINIO_SECRET_KEY) do echo '...waiting...' && sleep 1; done;
+            /usr/bin/mc mb myminio/site-scanning-snapshot;
+            /usr/bin/mc policy set download myminio/site-scanning-snapshot;
+            exit 0;
+            "
 
 networks:
     webnet:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     s3:
         container_name: s3
         image: minio/minio
-        command: server /data
+        command: server /site-scanning-snapshot
         ports:
             - "9000:9000"
         env_file:

--- a/entities/website.entity.ts
+++ b/entities/website.entity.ts
@@ -73,9 +73,4 @@ export class Website {
 
     return aggregate;
   }
-
-  toJSON() {
-    const result = this.serialized();
-    return JSON.stringify(result);
-  }
 }

--- a/entities/website.entity.ts
+++ b/entities/website.entity.ts
@@ -1,4 +1,4 @@
-import { Exclude, Expose } from 'class-transformer';
+import { classToPlain, Exclude, Expose } from 'class-transformer';
 import {
   Column,
   CreateDateColumn,
@@ -24,17 +24,11 @@ export class Website {
   @Exclude({ toPlainOnly: true })
   updated: string;
 
-  @OneToOne(
-    () => CoreResult,
-    coreResult => coreResult.website,
-  )
+  @OneToOne(() => CoreResult, (coreResult) => coreResult.website)
   @Exclude({ toPlainOnly: true })
   coreResult: CoreResult;
 
-  @OneToOne(
-    () => SolutionsResult,
-    solutionsResult => solutionsResult.website,
-  )
+  @OneToOne(() => SolutionsResult, (solutionsResult) => solutionsResult.website)
   @Exclude({ toPlainOnly: true })
   solutionsResult: SolutionsResult;
 
@@ -65,4 +59,23 @@ export class Website {
   @Column()
   @Exclude({ toPlainOnly: true })
   securityContactEmail: string;
+
+  serialized() {
+    const serializedWebsite = classToPlain(this);
+    const serializedCoreResult = classToPlain(this.coreResult);
+    const serializedSolutionsResult = classToPlain(this.solutionsResult);
+
+    const aggregate = {
+      ...serializedCoreResult,
+      ...serializedSolutionsResult,
+      ...serializedWebsite,
+    };
+
+    return aggregate;
+  }
+
+  toJSON() {
+    const result = this.serialized();
+    return JSON.stringify(result);
+  }
 }

--- a/libs/datetime/src/datetime.module.ts
+++ b/libs/datetime/src/datetime.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { DatetimeService } from './datetime.service';
+
+@Module({
+  providers: [DatetimeService],
+  exports: [DatetimeService],
+})
+export class DatetimeModule {}

--- a/libs/datetime/src/datetime.service.spec.ts
+++ b/libs/datetime/src/datetime.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DatetimeService } from './datetime.service';
+
+describe('DatetimeService', () => {
+  let service: DatetimeService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DatetimeService],
+    }).compile();
+
+    service = module.get<DatetimeService>(DatetimeService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/libs/datetime/src/datetime.service.ts
+++ b/libs/datetime/src/datetime.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class DatetimeService {
+  now() {
+    const now = new Date();
+    return now;
+  }
+}

--- a/libs/datetime/src/index.ts
+++ b/libs/datetime/src/index.ts
@@ -1,0 +1,2 @@
+export * from './datetime.module';
+export * from './datetime.service';

--- a/libs/datetime/tsconfig.lib.json
+++ b/libs/datetime/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "../../dist/libs/datetime"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/libs/snapshot/src/index.ts
+++ b/libs/snapshot/src/index.ts
@@ -1,0 +1,2 @@
+export * from './snapshot.module';
+export * from './snapshot.service';

--- a/libs/snapshot/src/snapshot-save-options.interface.ts
+++ b/libs/snapshot/src/snapshot-save-options.interface.ts
@@ -1,0 +1,4 @@
+export interface SnapshotSaveOptions {
+  name: string;
+  format?: string;
+}

--- a/libs/snapshot/src/snapshot.module.ts
+++ b/libs/snapshot/src/snapshot.module.ts
@@ -2,10 +2,11 @@ import { DatabaseModule } from '@app/database';
 import { LoggerModule } from '@app/logger';
 import { StorageModule } from '@app/storage';
 import { Module } from '@nestjs/common';
+import { DatetimeModule } from 'libs/datetime/src';
 import { SnapshotService } from './snapshot.service';
 
 @Module({
-  imports: [StorageModule, DatabaseModule, LoggerModule],
+  imports: [StorageModule, DatabaseModule, LoggerModule, DatetimeModule],
   providers: [SnapshotService],
   exports: [SnapshotService],
 })

--- a/libs/snapshot/src/snapshot.module.ts
+++ b/libs/snapshot/src/snapshot.module.ts
@@ -1,0 +1,12 @@
+import { DatabaseModule } from '@app/database';
+import { LoggerModule } from '@app/logger';
+import { StorageModule } from '@app/storage';
+import { Module } from '@nestjs/common';
+import { SnapshotService } from './snapshot.service';
+
+@Module({
+  imports: [StorageModule, DatabaseModule, LoggerModule],
+  providers: [SnapshotService],
+  exports: [SnapshotService],
+})
+export class SnapshotModule {}

--- a/libs/snapshot/src/snapshot.service.spec.ts
+++ b/libs/snapshot/src/snapshot.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SnapshotService } from './snapshot.service';
+
+describe('SnapshotService', () => {
+  let service: SnapshotService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SnapshotService],
+    }).compile();
+
+    service = module.get<SnapshotService>(SnapshotService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/libs/snapshot/src/snapshot.service.spec.ts
+++ b/libs/snapshot/src/snapshot.service.spec.ts
@@ -1,15 +1,24 @@
+import { DatabaseModule } from '@app/database';
+import { LoggerModule } from '@app/logger';
+import { StorageModule } from '@app/storage';
 import { Test, TestingModule } from '@nestjs/testing';
 import { SnapshotService } from './snapshot.service';
 
 describe('SnapshotService', () => {
   let service: SnapshotService;
+  let module: TestingModule;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    module = await Test.createTestingModule({
+      imports: [StorageModule, LoggerModule, DatabaseModule],
       providers: [SnapshotService],
     }).compile();
 
     service = module.get<SnapshotService>(SnapshotService);
+  });
+
+  afterAll(async () => {
+    await module.close();
   });
 
   it('should be defined', () => {

--- a/libs/snapshot/src/snapshot.service.spec.ts
+++ b/libs/snapshot/src/snapshot.service.spec.ts
@@ -64,8 +64,9 @@ describe('SnapshotService', () => {
     const body = JSON.stringify([website.serialized()]);
 
     mockWebsiteService.findAll.mockResolvedValue([website]);
-    await service.save({ name: fileName });
+    await service.weeklySnapshot();
 
     expect(mockStorageService.upload).toBeCalledWith(fileName, body);
+    expect(mockStorageService.copy).toBeCalled();
   });
 });

--- a/libs/snapshot/src/snapshot.service.ts
+++ b/libs/snapshot/src/snapshot.service.ts
@@ -2,12 +2,25 @@ import { WebsiteService } from '@app/database/websites/websites.service';
 import { LoggerService } from '@app/logger';
 import { StorageService } from '@app/storage';
 import { Injectable } from '@nestjs/common';
+import { SnapshotSaveOptions } from './snapshot-save-options.interface';
 
 @Injectable()
 export class SnapshotService {
   constructor(
     private storageService: StorageService,
-    private loggerService: LoggerService,
+    private logger: LoggerService,
     private websiteService: WebsiteService,
   ) {}
+
+  async save(options: SnapshotSaveOptions) {
+    this.logger.debug('finding all results...');
+    const results = await this.websiteService.findAll();
+    const serializedResults = results.map((website) => {
+      return website.serialized();
+    });
+    const stringified = JSON.stringify(serializedResults);
+    this.logger.debug('writing results...');
+
+    await this.storageService.upload(options.name, stringified);
+  }
 }

--- a/libs/snapshot/src/snapshot.service.ts
+++ b/libs/snapshot/src/snapshot.service.ts
@@ -1,0 +1,13 @@
+import { WebsiteService } from '@app/database/websites/websites.service';
+import { LoggerService } from '@app/logger';
+import { StorageService } from '@app/storage';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class SnapshotService {
+  constructor(
+    private storageService: StorageService,
+    private loggerService: LoggerService,
+    private websiteService: WebsiteService,
+  ) {}
+}

--- a/libs/snapshot/src/snapshot.service.ts
+++ b/libs/snapshot/src/snapshot.service.ts
@@ -2,6 +2,7 @@ import { WebsiteService } from '@app/database/websites/websites.service';
 import { LoggerService } from '@app/logger';
 import { StorageService } from '@app/storage';
 import { Injectable } from '@nestjs/common';
+import { DatetimeService } from 'libs/datetime/src';
 import { SnapshotSaveOptions } from './snapshot-save-options.interface';
 
 @Injectable()
@@ -10,6 +11,7 @@ export class SnapshotService {
     private storageService: StorageService,
     private logger: LoggerService,
     private websiteService: WebsiteService,
+    private datetimeService: DatetimeService,
   ) {}
 
   /**
@@ -19,7 +21,7 @@ export class SnapshotService {
    * archive bucket, and names it weekly-snapshot-<date-one-week-previous>.
    */
   async weeklySnapshot() {
-    const date = new Date();
+    const date = this.datetimeService.now();
     date.setDate(date.getDate() - 7);
 
     const newJsonName = `archive/weekly-snapshot-${date.toISOString()}.json`;

--- a/libs/snapshot/tsconfig.lib.json
+++ b/libs/snapshot/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "../../dist/libs/snapshot"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/libs/storage/src/config/storage.config.ts
+++ b/libs/storage/src/config/storage.config.ts
@@ -20,7 +20,7 @@ export default () => {
     return {
       s3: {
         bucketName: s3BucketName,
-        endpoint: `${s3Host}:${s3Port}`,
+        endpoint: `http://${s3Host}:${s3Port}`,
         accessKeyId: accessKeyId,
         secretAccessKey: secretAccessKey,
       },

--- a/libs/storage/src/config/storage.config.ts
+++ b/libs/storage/src/config/storage.config.ts
@@ -1,0 +1,29 @@
+export default () => {
+  if (process.env.VCAP_SERVICES) {
+    const vcap = JSON.parse(process.env.VCAP_SERVICES);
+    const s3 = vcap['s3'][0];
+    return {
+      s3: {
+        bucketName: s3.credentials.bucket,
+        endpoint: s3.credentials.fips_endpoint,
+        accessKeyId: s3.credentials.access_key_id,
+        secretAccessKey: s3.credentials.secret_access_key,
+      },
+    };
+  } else {
+    // config for local dev
+    const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+    const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+    const s3Host = process.env.S3_HOSTNAME;
+    const s3Port = process.env.S3_PORT;
+    const s3BucketName = process.env.S3_BUCKET_NAME;
+    return {
+      s3: {
+        bucketName: s3BucketName,
+        endpoint: `${s3Host}:${s3Port}`,
+        accessKeyId: accessKeyId,
+        secretAccessKey: secretAccessKey,
+      },
+    };
+  }
+};

--- a/libs/storage/src/index.ts
+++ b/libs/storage/src/index.ts
@@ -1,0 +1,2 @@
+export * from './storage.module';
+export * from './storage.service';

--- a/libs/storage/src/storage.module.ts
+++ b/libs/storage/src/storage.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { StorageService } from './storage.service';
+
+@Module({
+  providers: [StorageService],
+  exports: [StorageService],
+})
+export class StorageModule {}

--- a/libs/storage/src/storage.module.ts
+++ b/libs/storage/src/storage.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { StorageService } from './storage.service';
 
 @Module({
+  imports: [ConfigModule],
   providers: [StorageService],
   exports: [StorageService],
 })

--- a/libs/storage/src/storage.module.ts
+++ b/libs/storage/src/storage.module.ts
@@ -1,9 +1,10 @@
+import { LoggerModule } from '@app/logger';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { StorageService } from './storage.service';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, LoggerModule],
   providers: [StorageService],
   exports: [StorageService],
 })

--- a/libs/storage/src/storage.module.ts
+++ b/libs/storage/src/storage.module.ts
@@ -2,9 +2,15 @@ import { LoggerModule } from '@app/logger';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { StorageService } from './storage.service';
+import s3config from './config/storage.config';
 
 @Module({
-  imports: [ConfigModule, LoggerModule],
+  imports: [
+    ConfigModule.forRoot({
+      load: [s3config],
+    }),
+    LoggerModule,
+  ],
   providers: [StorageService],
   exports: [StorageService],
 })

--- a/libs/storage/src/storage.service.spec.ts
+++ b/libs/storage/src/storage.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StorageService } from './storage.service';
+
+describe('StorageService', () => {
+  let service: StorageService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [StorageService],
+    }).compile();
+
+    service = module.get<StorageService>(StorageService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/libs/storage/src/storage.service.spec.ts
+++ b/libs/storage/src/storage.service.spec.ts
@@ -1,14 +1,24 @@
-import { ConfigModule, ConfigService } from '@nestjs/config';
+import { LoggerService } from '@app/logger';
+import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import { mock, MockProxy } from 'jest-mock-extended';
 import { StorageService } from './storage.service';
 
 describe('StorageService', () => {
   let service: StorageService;
+  let mockLogger: MockProxy<LoggerService>;
 
   beforeEach(async () => {
+    mockLogger = mock<LoggerService>();
     const module: TestingModule = await Test.createTestingModule({
       imports: [ConfigModule],
-      providers: [StorageService],
+      providers: [
+        StorageService,
+        {
+          provide: LoggerService,
+          useValue: mockLogger,
+        },
+      ],
     }).compile();
 
     service = module.get<StorageService>(StorageService);

--- a/libs/storage/src/storage.service.spec.ts
+++ b/libs/storage/src/storage.service.spec.ts
@@ -1,3 +1,4 @@
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { StorageService } from './storage.service';
 
@@ -6,6 +7,7 @@ describe('StorageService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
       providers: [StorageService],
     }).compile();
 

--- a/libs/storage/src/storage.service.ts
+++ b/libs/storage/src/storage.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class StorageService {}

--- a/libs/storage/src/storage.service.ts
+++ b/libs/storage/src/storage.service.ts
@@ -1,4 +1,23 @@
+import { S3 } from '@aws-sdk/client-s3';
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
-export class StorageService {}
+export class StorageService {
+  s3: S3;
+  bucketName: string;
+  constructor(private configService: ConfigService) {
+    this.s3 = new S3({});
+    this.bucketName = this.configService.get<string>('S3_BUCKET_NAME');
+  }
+
+  async upload(fileName: string, body: string) {
+    const result = await this.s3.putObject({
+      Bucket: this.bucketName,
+      Key: fileName,
+      Body: body,
+    });
+
+    return result;
+  }
+}

--- a/libs/storage/src/storage.service.ts
+++ b/libs/storage/src/storage.service.ts
@@ -1,32 +1,34 @@
 import { LoggerService } from '@app/logger';
-import { S3 } from '@aws-sdk/client-s3';
+import * as AWS from 'aws-sdk';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class StorageService {
-  private s3: S3;
+  private s3: AWS.S3;
   constructor(
     private configService: ConfigService,
     private logger: LoggerService,
   ) {
-    this.s3 = new S3({
+    this.s3 = new AWS.S3({
       endpoint: this.configService.get<string>('s3.endpoint'),
-      credentials: {
-        accessKeyId: this.configService.get<string>('s3.accessKeyId'),
-        secretAccessKey: this.configService.get<string>('s3.secretAccessKey'),
-      },
+      accessKeyId: this.configService.get<string>('s3.accessKeyId'),
+      secretAccessKey: this.configService.get<string>('s3.secretAccessKey'),
+      s3ForcePathStyle: true,
+      signatureVersion: 'v4',
     });
   }
 
   async upload(fileName: string, body: string) {
     this.logger.debug('attempting s3 putObject request...');
     try {
-      await this.s3.putObject({
-        Bucket: this.configService.get<string>('s3.bucketName'),
-        Key: fileName,
-        Body: body,
-      });
+      await this.s3
+        .putObject({
+          Bucket: this.configService.get<string>('s3.bucketName'),
+          Key: fileName,
+          Body: body,
+        })
+        .promise();
       this.logger.debug('s3 request completed');
     } catch (error) {
       const err = error as Error;

--- a/libs/storage/src/storage.service.ts
+++ b/libs/storage/src/storage.service.ts
@@ -1,23 +1,32 @@
+import { LoggerService } from '@app/logger';
 import { S3 } from '@aws-sdk/client-s3';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class StorageService {
-  s3: S3;
-  bucketName: string;
-  constructor(private configService: ConfigService) {
+  private s3: S3;
+  private bucketName: string;
+  constructor(
+    private configService: ConfigService,
+    private logger: LoggerService,
+  ) {
     this.s3 = new S3({});
     this.bucketName = this.configService.get<string>('S3_BUCKET_NAME');
   }
 
   async upload(fileName: string, body: string) {
-    const result = await this.s3.putObject({
-      Bucket: this.bucketName,
-      Key: fileName,
-      Body: body,
-    });
-
-    return result;
+    this.logger.debug('attempting s3 putObject request...');
+    try {
+      await this.s3.putObject({
+        Bucket: this.bucketName,
+        Key: fileName,
+        Body: body,
+      });
+      this.logger.debug('s3 request completed');
+    } catch (error) {
+      const err = error as Error;
+      this.logger.error(`s3 request failed with: ${err.message}`, err.stack);
+    }
   }
 }

--- a/libs/storage/src/storage.service.ts
+++ b/libs/storage/src/storage.service.ts
@@ -6,20 +6,24 @@ import { ConfigService } from '@nestjs/config';
 @Injectable()
 export class StorageService {
   private s3: S3;
-  private bucketName: string;
   constructor(
     private configService: ConfigService,
     private logger: LoggerService,
   ) {
-    this.s3 = new S3({});
-    this.bucketName = this.configService.get<string>('S3_BUCKET_NAME');
+    this.s3 = new S3({
+      endpoint: this.configService.get<string>('s3.endpoint'),
+      credentials: {
+        accessKeyId: this.configService.get<string>('s3.accessKeyId'),
+        secretAccessKey: this.configService.get<string>('s3.secretAccessKey'),
+      },
+    });
   }
 
   async upload(fileName: string, body: string) {
     this.logger.debug('attempting s3 putObject request...');
     try {
       await this.s3.putObject({
-        Bucket: this.bucketName,
+        Bucket: this.configService.get<string>('s3.bucketName'),
         Key: fileName,
         Body: body,
       });

--- a/libs/storage/tsconfig.lib.json
+++ b/libs/storage/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "../../dist/libs/storage"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/manifest.yml
+++ b/manifest.yml
@@ -24,6 +24,7 @@ applications:
   health-check-type: process
   env:
     CORE_SCAN_SCHEDULE: "0 0 * * *"
+    SNAPSHOT_SCHEDULE: "0 12 * * Sun"
 
 
 - name: site-scanner-consumer

--- a/manifest.yml
+++ b/manifest.yml
@@ -24,7 +24,7 @@ applications:
   health-check-type: process
   env:
     CORE_SCAN_SCHEDULE: "0 0 * * *"
-    SNAPSHOT_SCHEDULE: "0 12 * * Sun"
+    SNAPSHOT_SCHEDULE: "0 0 * * *"
 
 
 - name: site-scanner-consumer

--- a/manifest.yml
+++ b/manifest.yml
@@ -16,6 +16,7 @@ applications:
   services:
     - scanner-postgres
     - scanner-message-queue
+    - scanner-public-storage
   memory: 2048M
   instances: 1
   no-route: true

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -124,6 +124,15 @@
       "compilerOptions": {
         "tsConfigPath": "libs/snapshot/tsconfig.lib.json"
       }
+    },
+    "datetime": {
+      "type": "library",
+      "root": "libs/datetime",
+      "entryFile": "index",
+      "sourceRoot": "libs/datetime/src",
+      "compilerOptions": {
+        "tsConfigPath": "libs/datetime/tsconfig.lib.json"
+      }
     }
   }
 }

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -115,6 +115,15 @@
       "compilerOptions": {
         "tsConfigPath": "libs/storage/tsconfig.lib.json"
       }
+    },
+    "snapshot": {
+      "type": "library",
+      "root": "libs/snapshot",
+      "entryFile": "index",
+      "sourceRoot": "libs/snapshot/src",
+      "compilerOptions": {
+        "tsConfigPath": "libs/snapshot/tsconfig.lib.json"
+      }
     }
   }
 }

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -106,6 +106,15 @@
       "compilerOptions": {
         "tsConfigPath": "libs/solutions-scanner/tsconfig.lib.json"
       }
+    },
+    "storage": {
+      "type": "library",
+      "root": "libs/storage",
+      "entryFile": "index",
+      "sourceRoot": "libs/storage/src",
+      "compilerOptions": {
+        "tsConfigPath": "libs/storage/tsconfig.lib.json"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,1150 @@
         "symbol-observable": "2.0.3"
       }
     },
+    "@aws-crypto/crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.0.0.tgz",
+      "integrity": "sha512-wr4EyCv3ZfLH3Sg7FErV6e/cLhpk9rUP/l5322y8PRgpQsItdieaLbtE4aDOR+dxl8U7BG9FIwWXH4TleTDZ9A==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+      "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.0.0.tgz",
+      "integrity": "sha512-uSufui4ZktC5lYX6bDxgBgNboxGyw9V9V+rlcNsNTxh4YPhOdCslwJMGntiWOBRGAgXhhvWi7FqnTS2SaT3cpg==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-crypto/supports-web-crypto": "^1.0.0",
+        "@aws-sdk/types": "^1.0.0-rc.1",
+        "@aws-sdk/util-locate-window": "^1.0.0-rc.1",
+        "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0.tgz",
+      "integrity": "sha512-89kqtFs/tdHBFHEBXZ4UXlCISswvEor3BVVOriR68Tbk1Qe1zBOZtfbSOt3CDT69z88x5uM558YW9k8I1xei5A==",
+      "requires": {
+        "@aws-sdk/types": "^1.0.0-rc.1",
+        "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+      "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-1.0.0-rc.10.tgz",
+      "integrity": "sha512-WNF6+oVMqBpWWahdapd55y0co8/NiTPcoTvZdTc11gTqHoqBoRe3C+srURI7iF/+uYwjUUjpOFQUNscEABKuYg==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/chunked-blob-reader": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-1.0.0-rc.8.tgz",
+      "integrity": "sha512-i4cTVFbetg7FRUmsDZ9wLdC0lR4qMNH0rZ5f+TQPwhe/1yyMmKLvsza9P8Gli4AeNSLumcSbadvN0spbIvRQng==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/chunked-blob-reader-native": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-1.0.0-rc.8.tgz",
+      "integrity": "sha512-0LIjlX9QueugfuHfTh45hK+gxSo4aKbcaRy+iM7QICl4NGGWMu6YJ7GiLJo5lkeu4Y55ir9yq1KZ/x5LHePVtg==",
+      "requires": {
+        "@aws-sdk/util-base64-browser": "1.0.0-rc.8",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/client-s3": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-1.0.0-rc.10.tgz",
+      "integrity": "sha512-dwoERl2xe1tfcwV9F+jcLzOOmoCsv2JtcQTKzg+HtsEON45m1Mx5SkRe5nAvh1b7xDz9/XwZjb8+WN5YoBcrqw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "1.0.0-rc.10",
+        "@aws-sdk/credential-provider-node": "1.0.0-rc.10",
+        "@aws-sdk/eventstream-serde-browser": "1.0.0-rc.10",
+        "@aws-sdk/eventstream-serde-config-resolver": "1.0.0-rc.10",
+        "@aws-sdk/eventstream-serde-node": "1.0.0-rc.10",
+        "@aws-sdk/fetch-http-handler": "1.0.0-rc.10",
+        "@aws-sdk/hash-blob-browser": "1.0.0-rc.10",
+        "@aws-sdk/hash-node": "1.0.0-rc.10",
+        "@aws-sdk/hash-stream-node": "1.0.0-rc.10",
+        "@aws-sdk/invalid-dependency": "1.0.0-rc.8",
+        "@aws-sdk/md5-js": "1.0.0-rc.10",
+        "@aws-sdk/middleware-apply-body-checksum": "1.0.0-rc.10",
+        "@aws-sdk/middleware-bucket-endpoint": "1.0.0-rc.10",
+        "@aws-sdk/middleware-content-length": "1.0.0-rc.10",
+        "@aws-sdk/middleware-expect-continue": "1.0.0-rc.10",
+        "@aws-sdk/middleware-host-header": "1.0.0-rc.10",
+        "@aws-sdk/middleware-location-constraint": "1.0.0-rc.10",
+        "@aws-sdk/middleware-logger": "1.0.0-rc.10",
+        "@aws-sdk/middleware-retry": "1.0.0-rc.10",
+        "@aws-sdk/middleware-sdk-s3": "1.0.0-rc.10",
+        "@aws-sdk/middleware-serde": "1.0.0-rc.10",
+        "@aws-sdk/middleware-signing": "1.0.0-rc.10",
+        "@aws-sdk/middleware-ssec": "1.0.0-rc.10",
+        "@aws-sdk/middleware-stack": "1.0.0-rc.10",
+        "@aws-sdk/middleware-user-agent": "1.0.0-rc.10",
+        "@aws-sdk/node-config-provider": "1.0.0-rc.10",
+        "@aws-sdk/node-http-handler": "1.0.0-rc.10",
+        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "@aws-sdk/smithy-client": "1.0.0-rc.10",
+        "@aws-sdk/url-parser-browser": "1.0.0-rc.10",
+        "@aws-sdk/url-parser-node": "1.0.0-rc.10",
+        "@aws-sdk/util-base64-browser": "1.0.0-rc.8",
+        "@aws-sdk/util-base64-node": "1.0.0-rc.8",
+        "@aws-sdk/util-body-length-browser": "1.0.0-rc.8",
+        "@aws-sdk/util-body-length-node": "1.0.0-rc.8",
+        "@aws-sdk/util-user-agent-browser": "1.0.0-rc.10",
+        "@aws-sdk/util-user-agent-node": "1.0.0-rc.10",
+        "@aws-sdk/util-utf8-browser": "1.0.0-rc.8",
+        "@aws-sdk/util-utf8-node": "1.0.0-rc.8",
+        "@aws-sdk/util-waiter": "1.0.0-rc.10",
+        "@aws-sdk/xml-builder": "1.0.0-rc.8",
+        "fast-xml-parser": "^3.16.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-1.0.0-rc.10.tgz",
+      "integrity": "sha512-Z5Rc/QAyUrtRhOmhLAgGlFG3li2ihxkClDkbX24z8QxU5M9D3SGu+Wyur2nHX9G6ssgNkOcKfiy+H4dSPQCV8g==",
+      "requires": {
+        "@aws-sdk/signature-v4": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-1.0.0-rc.10.tgz",
+      "integrity": "sha512-robMjRq5pO3grBbzpC8hNHkjTut57OhbneDAvgN8FAabjcDf1ppufyMdPDbBrIM2omcbqUc6LN1GMS3BMlx1Gg==",
+      "requires": {
+        "@aws-sdk/property-provider": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-1.0.0-rc.10.tgz",
+      "integrity": "sha512-yTZSNIANwoJIkRWx9vGJ7v+UiMa/e/Rhj1TPTRzUEw8vxTJ6laDa+aJpm6vVSVBXJpZwtYmCzwrTx6Flw5H3Sw==",
+      "requires": {
+        "@aws-sdk/property-provider": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-1.0.0-rc.10.tgz",
+      "integrity": "sha512-LDsBUgW1xcv9P2VYuTq+A1NiG3snw0OxLvOxezDVQ35vtyo5LAnqSGQtxt3QrwykQpOs8fuVhtJg7jTy4vNarg==",
+      "requires": {
+        "@aws-sdk/property-provider": "1.0.0-rc.10",
+        "@aws-sdk/shared-ini-file-loader": "1.0.0-rc.9",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-1.0.0-rc.10.tgz",
+      "integrity": "sha512-lZfHzcNYIYDVaNzKZB0NUa8yxgzPzNQIJNx7zkNLRo+IJWHv8LOLUDKL99tDz4ubEQQbJHPIdtoPpixrYLzl4w==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "1.0.0-rc.10",
+        "@aws-sdk/credential-provider-imds": "1.0.0-rc.10",
+        "@aws-sdk/credential-provider-ini": "1.0.0-rc.10",
+        "@aws-sdk/credential-provider-process": "1.0.0-rc.10",
+        "@aws-sdk/property-provider": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-1.0.0-rc.10.tgz",
+      "integrity": "sha512-MjmgtgaRIz3ob+wYbgytNUBzVtwrgJoPJHOd1I56H/Y4rQD/lDb2xqxiFYu+KPzCMW6R4PtrIcFeOiiFtqctPg==",
+      "requires": {
+        "@aws-sdk/credential-provider-ini": "1.0.0-rc.10",
+        "@aws-sdk/property-provider": "1.0.0-rc.10",
+        "@aws-sdk/shared-ini-file-loader": "1.0.0-rc.9",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/eventstream-marshaller": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-1.0.0-rc.10.tgz",
+      "integrity": "sha512-UNVmo9gGkmYULhyZjkkiwAc2mMsXxVprnu8uurvRTsqzh8E7oL9UV2jp0tpCpJ3l64WtWIMQXH65Kf0ZKOXmAw==",
+      "requires": {
+        "@aws-crypto/crc32": "^1.0.0",
+        "@aws-sdk/util-hex-encoding": "1.0.0-rc.8",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-browser": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-1.0.0-rc.10.tgz",
+      "integrity": "sha512-FPaPjMJM1VArkdg2CvbxgaqVAuz0o3cJ7wIg1ahCu/y7hyrg8VIlpDvmRFOMZYpsVEygz70Z9GqBBQoU/p4sXg==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "1.0.0-rc.10",
+        "@aws-sdk/eventstream-serde-universal": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-1.0.0-rc.10.tgz",
+      "integrity": "sha512-JAqaywsPLOs02kDGMjfNiqgZxawdOfUHCcKqK4tKUbceXQcDjge6u0W0O/5qDkoMRAN8g3w8m67NUoCodBMt9g==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-node": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-1.0.0-rc.10.tgz",
+      "integrity": "sha512-wdBgjIbMmq3NXsdl3z7oiOzeJ0Xu4/AHmcKt4re/jby19Y/c0Eu+saXTii5Xs19jqCKqG0zgJXbPHcFz6JSKXg==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "1.0.0-rc.10",
+        "@aws-sdk/eventstream-serde-universal": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-universal": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-1.0.0-rc.10.tgz",
+      "integrity": "sha512-R1dJ79mkKRJISjX8yGju1+PeTOQBECZLhYqhANS0YLzrVgt18y7yHu1BNBfcxCNs1ZyWir2BpYo3pA/Yuk7wLg==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-1.0.0-rc.10.tgz",
+      "integrity": "sha512-bxuDqnC6iN/jrvU0hWEPTk3FsWtkcZ2EJuL83bXeRph++P/JXYsjOlFMjaFvplTXVX8vhc9SULq2o5h3xlN79Q==",
+      "requires": {
+        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "@aws-sdk/querystring-builder": "1.0.0-rc.10",
+        "@aws-sdk/util-base64-browser": "1.0.0-rc.8",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/hash-blob-browser": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-1.0.0-rc.10.tgz",
+      "integrity": "sha512-2jUSE+FlFlVA6hZA3ATz0XDwypMNs2i17kfgmp3oDLS3jJoTEmVeEMHyGmd23VpIQduO0/aIx3i5Qc6ukzwqVg==",
+      "requires": {
+        "@aws-sdk/chunked-blob-reader": "1.0.0-rc.8",
+        "@aws-sdk/chunked-blob-reader-native": "1.0.0-rc.8",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-1.0.0-rc.10.tgz",
+      "integrity": "sha512-HaDZ17h8awZSZu6aqjygLD3mYFIbQnrztrlz3GWeSN3P4yWhSXsppv3o3LDIlMAQFwleuwUP8Ux9Nl1qzjtSvQ==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "1.0.0-rc.8",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/hash-stream-node": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-1.0.0-rc.10.tgz",
+      "integrity": "sha512-Gd/im5B0u/btT/9xbmp3reM4acNbOFFgdMaAEyvN57dQel6LCOb8AnYkFRfQIelKUI97LSlrpHJmf7RWGeI2rA==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-1.0.0-rc.8.tgz",
+      "integrity": "sha512-T7fMj3y8tFVH+t9T9U9htXya8THjV0IzWvec16CVYOtThRdj5RAN9XXkW6odgyJVz18mVWSSjzgqCwa0W0FIkQ==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-1.0.0-rc.8.tgz",
+      "integrity": "sha512-qink0kc2Px0wPY3v2hC5uvQFYfiFJKDkjcDw7IFCyangGrcIwgOjwzSVnf/cRvdDyyy3l62EXPCdtitnu9MmkA==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/md5-js": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-1.0.0-rc.10.tgz",
+      "integrity": "sha512-CEe8al8RxjbKlkHVGe4i3LhcVjMDdsoqyUKWR/aSfFnf4RC3K/xXfyjXOW66K9bHisbakcctiqTtLBoLuTlppQ==",
+      "requires": {
+        "@aws-sdk/util-utf8-browser": "1.0.0-rc.8",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-apply-body-checksum": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-1.0.0-rc.10.tgz",
+      "integrity": "sha512-aaCeQZEe/ERZYptAhyc2vkDWQSJqH9dDQfWVknncxgF21hnGRlSyXqzzAM9/RTPbtGWqktxcis1cZ7xAtQzbDw==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "1.0.0-rc.8",
+        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-bucket-endpoint": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-1.0.0-rc.10.tgz",
+      "integrity": "sha512-nCGjzbB2ENoH/RMoKboiglYBn6G3ib1pb08Jqnshr9EicaCz1A9KrJtVdqsPnkvzB8w1JRPrmCNJuC3hC1Ueww==",
+      "requires": {
+        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "@aws-sdk/util-arn-parser": "1.0.0-rc.8",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-1.0.0-rc.10.tgz",
+      "integrity": "sha512-u1mhrg8joX/YZnqwicK5IxRRGnKGNpnSyY3h7iLa1gh2s2UCsMQi0hL36e3TP2v0LjhpW+nAHUrd47lxppkSig==",
+      "requires": {
+        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-expect-continue": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-1.0.0-rc.10.tgz",
+      "integrity": "sha512-aUbgwbjfnY7CI9nU36yLdjI2fmaN0l6fjPOQH5HapcilyrMG+LQo3WMsDMCYl//weJptse20Tptv6eSTNci76w==",
+      "requires": {
+        "@aws-sdk/middleware-header-default": "1.0.0-rc.10",
+        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-header-default": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-1.0.0-rc.10.tgz",
+      "integrity": "sha512-9W0Kr2nJvvMhKA8JDcnugPo7/LANnB/Io3vTPSSajaoR6Lnxcb1SaLAXJUjdH+A4+MG8QIfCbOB3bu1KmoAkEw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-1.0.0-rc.10.tgz",
+      "integrity": "sha512-/YC/XJKKUDvYDHRH726F1aZsdKQ3sjT3RVwdPXiHeECYiNpQ+0uUQ7n81CoySoRTNuHLTgGHh6ctAcJUU1Xj+g==",
+      "requires": {
+        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-location-constraint": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-1.0.0-rc.10.tgz",
+      "integrity": "sha512-nF8zII2aT/KrtljOEfyKA2Qfmy9zRwQP9nljzsRq8zn4uB8+dGnDgc+BdyavAErIoB+uf/0iswrYSPlSlEy4Wg==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-1.0.0-rc.10.tgz",
+      "integrity": "sha512-xO380+N1KfRXudcOYgR1rUZp1blxuYUADIvYXF6xrE2K5konuynEChLlzHy0cmtqoHgvGDmVdhDbkDdlw7MB0g==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-1.0.0-rc.10.tgz",
+      "integrity": "sha512-24ycZ/2iqTk1G7/YrLJbbhRA2vV+SosTKf63oEf1r7DPYVN/q6YMMXo0XuCmai6mGrtV6JEclSivBHmWo1zAYg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "@aws-sdk/service-error-classification": "1.0.0-rc.10",
+        "react-native-get-random-values": "^1.4.0",
+        "tslib": "^1.8.0",
+        "uuid": "^3.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-s3": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-1.0.0-rc.10.tgz",
+      "integrity": "sha512-xYs3JX6Ll1Wr+HQSJK8qlvRTnsZ41fOD5EZRSOiisW9A3Kc4U+P3ELNWYCJhIGuZMgDJQNUMkjNP+MFiquJHCg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "@aws-sdk/util-arn-parser": "1.0.0-rc.8",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-1.0.0-rc.10.tgz",
+      "integrity": "sha512-e5MMxJT4THdWYXLvsDFwwEBSqO1iCPiSeVCbczLe2VwVaDkhJlUtHXfJjy31wZYAubS/AJH+YPO6JFaWxj7DOQ==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-1.0.0-rc.10.tgz",
+      "integrity": "sha512-Ohyj8Ob0yHkCi8YxG5IZ2va/5daWXHtJD90otUOWu4HdHAAJ1xtkFzJUVO1E1LZUsuLcR2WDuGuGnznOMbSVmw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "@aws-sdk/signature-v4": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-ssec": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-1.0.0-rc.10.tgz",
+      "integrity": "sha512-GZNZn1bYJrxDwpu1D3EkpbiuPuxy/37Ue4t7187/e0vvqM2gxNF6bxinX4K5Z3xi+c5Px9PbLylZjzVH7tBoEQ==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-1.0.0-rc.10.tgz",
+      "integrity": "sha512-3C36t4wFTLgBkmLOiaHCUoysIUIKjBSCGVVvnmE8S4SCGhBkPBjKcHMPjA94ru8/D+dSggSSZxixeCCa1KjePQ==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-1.0.0-rc.10.tgz",
+      "integrity": "sha512-pBGSlqParM0pv5FmSl6ulhJPwmcA2ZagjYdoNdsb9C1xh8vWTHtlIYioRyIWjJYK4y3g3mwrmE7577OAZMIgtw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-1.0.0-rc.10.tgz",
+      "integrity": "sha512-gdp9Zz/m4F+fTTn7CmZQnY0fNJaSFElHSUVA1L8n2F+3t9TRPJCeymPHO6cTM2o3d29FCcCBN79JT2UhZ8x4Yg==",
+      "requires": {
+        "@aws-sdk/property-provider": "1.0.0-rc.10",
+        "@aws-sdk/shared-ini-file-loader": "1.0.0-rc.9",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-1.0.0-rc.10.tgz",
+      "integrity": "sha512-+Sk4gUl9sRSburG0uUdEbJ2uiQcswBIuCqrCtNw4oHqc9OTcXg7N5OtHZQFjl0YHUPQ5eB1DVwKWqtdpD2fCRA==",
+      "requires": {
+        "@aws-sdk/abort-controller": "1.0.0-rc.10",
+        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "@aws-sdk/querystring-builder": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-1.0.0-rc.10.tgz",
+      "integrity": "sha512-Vqz/RkmNjS2YCNK+mrdWZALDHKnPdgW6eAFibge0F9xHv+6PPmHFs0/ggJX8owZozQCbNQtsJ+up4kzF1q4Xxg==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-1.0.0-rc.10.tgz",
+      "integrity": "sha512-ON7GR9HEqsx2tZD2UnPqPVlDFADiTBMm6BnUQlxOIM7q0NEvKLz9ZaKxwgM5Hq5pOLg/uGAMpD1PJAUXGd6K+w==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-1.0.0-rc.10.tgz",
+      "integrity": "sha512-Og6s3NfZcxez/77vD0uC34HRcp9e0uIxzJcMhXdL9C0y/eRcIAZrH0ozjfwFSAulTeVuR6OV4sXz9Ucv7grh3g==",
+      "requires": {
+        "@aws-sdk/util-uri-escape": "1.0.0-rc.8",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-1.0.0-rc.10.tgz",
+      "integrity": "sha512-91A5Hp1MUdxOLMy02U21lOX7fFbjGY4DgSJ84OsOX0BVAiGJufyFEHG2pDAjAJSuSDgbgrlrW3uk5cNqkyqbJw==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-1.0.0-rc.10.tgz",
+      "integrity": "sha512-GIkVdPbNYujnMWS/VGjhnVL5bmdD+Qr4Ov2Fpd5z5+NwIgvMP8W60I+xb8GQsebBAOVg+B2btJikv3jPME/jgA=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-1.0.0-rc.9.tgz",
+      "integrity": "sha512-Nyw4/PGMxm0VPEI3d+Aj0cRz/q/DSM83EyYTzjT0lbE7hgdNT1Y8NljkxfxTa2uQQLjDZUtmkIfVOJ42/HriMw==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-1.0.0-rc.10.tgz",
+      "integrity": "sha512-qekaz/KHDt3gquk4t4A8AbhJfdo86OrKIgh5RAIHUw/5v3tsojh6Z3GLsYpf1+YrmG8HGXzv4g2sdN18n1tl5w==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "1.0.0-rc.8",
+        "@aws-sdk/util-hex-encoding": "1.0.0-rc.8",
+        "@aws-sdk/util-uri-escape": "1.0.0-rc.8",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-1.0.0-rc.10.tgz",
+      "integrity": "sha512-xpV5DlOSCORf0pLR/tvRa8QF4Bdf3lBMVfCbfWYOaONUw93oulKYWnFlSHh4MK3JNDox4hBYf/owu3SBTkIAhA==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-1.0.0-rc.10.tgz",
+      "integrity": "sha512-9gwhYnkTNuYZ+etCtM4T8gjpZ0SWSXbzQxY34UjSS+dt3C/UnbX0J22tMahp/9Z1yCa9pihtXrkD+nO2xn7nVQ=="
+    },
+    "@aws-sdk/url-parser-browser": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-browser/-/url-parser-browser-1.0.0-rc.10.tgz",
+      "integrity": "sha512-1KiynhAbGr/bAkNlbx0JHXyJJj6ndcHzQo1RHK0lJazObWSiUjs+CSHDdMB4RMI5mKTEzP5HBBH2B/1us4JNTQ==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/url-parser-node": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-node/-/url-parser-node-1.0.0-rc.10.tgz",
+      "integrity": "sha512-GakSZZ/xMvw5JPQ8pLIhZ27IRO2b5Qb0iigknKQxjvx9WVDjS7FRUHZsG0Pct/gz0LuSmouQlCd2/458RbboOg==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "1.0.0-rc.10",
+        "tslib": "^1.8.0",
+        "url": "^0.11.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/util-arn-parser": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-1.0.0-rc.8.tgz",
+      "integrity": "sha512-uIx9fAzM51eBexZ7jcczPQaF79L4ENUHqRUJL3AUzcsjK2NSXzTGvRZiS8EmAqqZH7kgttEchp2e35SXPSAaYw==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-1.0.0-rc.8.tgz",
+      "integrity": "sha512-3cKuaOSM3PedrnROeqiWbRUN29XLDYHeiJg/JFM1IW1JxwW6mOM8upD4WqL13BUJwPax8MfaeG9xKCMZP0OaNA==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-1.0.0-rc.8.tgz",
+      "integrity": "sha512-/RsrJYdNfXTEiAg9gYCB8w1lV7zHcaxDA0KMkvZGv5+NEjF40mKLb/oU71l3+42NJdR8+2iPJaWg5K1TxQp5tQ==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "1.0.0-rc.8",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-1.0.0-rc.8.tgz",
+      "integrity": "sha512-wN0SMHTZUiCFEDSoi66ut9N6QX31Anfi/cus4Tz/1wvHJPJbMrxR1EgH1djfBg2Dtk6iGosrdb4uACdwkzatGQ==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-1.0.0-rc.8.tgz",
+      "integrity": "sha512-QFx6no7MGmuBrs+Sf1AalJZKqczAR73wMccqmw7fJuRJWAqItp5NflOh2y6tjm5Q1PRP4hsLyGii1QIm8/NYSw==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-1.0.0-rc.8.tgz",
+      "integrity": "sha512-NXIuqqkEsf15Qw7oJoChwGP+oO42+tJzjjgKcV+UVNmzwbXHn10XtmPwL7hgDTl2dj2xMrCoheraLKJ5jJUEFA==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "1.0.0-rc.8",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-1.0.0-rc.8.tgz",
+      "integrity": "sha512-7tZgYNwHsvA/Tw7LDSSOXzacb6pbz3lv7xICVMP3MTuprj4MOZmjBg5nNpFp2zPd2xKDH5DhfNMvrex3cbS/tg==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-1.0.0-rc.8.tgz",
+      "integrity": "sha512-TvqeA4fgmZ0A0x3K+qVj/OSWEFHGZjzpVuyXlm1EYOf7NQ9VWRlokEn1MYKuL+t7al9ZeQyi16D8Dn7DW1eidw==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-1.0.0-rc.8.tgz",
+      "integrity": "sha512-nYXuNr5pB62FK1ZvhXx04A4NIfP2JZNHf/R3LMW2TQgYW/yH6mHde1f8lEUISc/Dnc336DNkxN7T30vaRUcvLg==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-1.0.0-rc.10.tgz",
+      "integrity": "sha512-nBN4auoCH9kbgo7CZG0k8MD4hjWx7vLzrrwpaKNzjNYC3UgeXCAey29ccexp1tv3hNnCvwtk43SGJkXa+7NLvw==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-1.0.0-rc.10.tgz",
+      "integrity": "sha512-x7E8c5ISflKDazSNix3S/2JPVImR01JT7re/xG5m+ZsqAHu842cnNMUtYpk0nXpgRRED+/j3Fyybqa2nrZOevQ==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-rc.8.tgz",
+      "integrity": "sha512-clncPMJ23rxCIkZ9LoUC8SowwZGxWyN2TwRb0XvW/Cv9EavkRgRCOrCpneGyC326lqtMKx36onnpaSRHxErUYw==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-1.0.0-rc.8.tgz",
+      "integrity": "sha512-7nu5Yk8agcK/y5X/CV9u7P8Q2OW6q+2vmuOpzNXDVM/KR3QX1g9PC1P0Isc4v74Q5t/hRkJxq2auIMJKZSAjDA==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "1.0.0-rc.8",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/util-waiter": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-1.0.0-rc.10.tgz",
+      "integrity": "sha512-dwF5bXgWG1VDTxyACzCY+Kfa3JlmA9vh2gbQGJURLdzHPdyJE+3UegCp7YbgOkOQj8OnvISC66usZaoWf8fqIQ==",
+      "requires": {
+        "@aws-sdk/abort-controller": "1.0.0-rc.10",
+        "@aws-sdk/types": "1.0.0-rc.10",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "1.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-1.0.0-rc.8.tgz",
+      "integrity": "sha512-8x4nbr4/N4NEpIs6WwbkNQdefQqZI9l3zLfs1a16E2RNEUWtM0RocU4OoA73yyGUZNmDjiZ3tFsx9aDMRe21bw==",
+      "requires": {
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -5241,6 +6385,11 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "fast-base64-decode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
+      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q=="
+    },
     "fast-csv": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
@@ -5298,6 +6447,11 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
+    "fast-xml-parser": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.5.tgz",
+      "integrity": "sha512-lEvThd1Xq+CCylf1n+05bUZCDZjTufaaaqpxM3JZ+4iDqtlG+d/oKgtMmg9GEMOuzBgUoalIzFOaClht9YiGJQ=="
     },
     "fastq": {
       "version": "1.9.0",
@@ -9754,6 +10908,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -9777,6 +10936,14 @@
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      }
+    },
+    "react-native-get-random-values": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.5.0.tgz",
+      "integrity": "sha512-LK+Wb8dEimJkd/dub7qziDmr9Tw4chhpzVeQ6JDo4czgfG4VXbptRyOMdu8503RiMF6y9pTH6ZUTkrrpprqT7w==",
+      "requires": {
+        "fast-base64-decode": "^1.0.0"
       }
     },
     "read-pkg": {
@@ -11895,6 +13062,22 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
     },
     "use": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,14 @@
         "tslib": "^1.11.1"
       },
       "dependencies": {
+        "@aws-sdk/util-utf8-browser": {
+          "version": "1.0.0-rc.8",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-rc.8.tgz",
+          "integrity": "sha512-clncPMJ23rxCIkZ9LoUC8SowwZGxWyN2TwRb0XvW/Cv9EavkRgRCOrCpneGyC326lqtMKx36onnpaSRHxErUYw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          }
+        },
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -118,6 +126,14 @@
         "tslib": "^1.11.1"
       },
       "dependencies": {
+        "@aws-sdk/util-utf8-browser": {
+          "version": "1.0.0-rc.8",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-rc.8.tgz",
+          "integrity": "sha512-clncPMJ23rxCIkZ9LoUC8SowwZGxWyN2TwRb0XvW/Cv9EavkRgRCOrCpneGyC326lqtMKx36onnpaSRHxErUYw==",
+          "requires": {
+            "tslib": "^1.8.0"
+          }
+        },
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -141,9 +157,9 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-1.0.0-rc.10.tgz",
-      "integrity": "sha512-WNF6+oVMqBpWWahdapd55y0co8/NiTPcoTvZdTc11gTqHoqBoRe3C+srURI7iF/+uYwjUUjpOFQUNscEABKuYg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-vNLvkOp4CRovVvm7OGOTiQYnpRK3EgrP0fVOjVHEqo3Qep3u2JJi/Ifo931K/Yd7cWlbtLbttqguGBCPcWWlgw==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -156,9 +172,9 @@
       }
     },
     "@aws-sdk/chunked-blob-reader": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-1.0.0-rc.8.tgz",
-      "integrity": "sha512-i4cTVFbetg7FRUmsDZ9wLdC0lR4qMNH0rZ5f+TQPwhe/1yyMmKLvsza9P8Gli4AeNSLumcSbadvN0spbIvRQng==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.0.0.tgz",
+      "integrity": "sha512-FVAYcWnLHoMT6WVuzz3BxkZ9mDHTUtG1bXAl0EnE7xdK1wcwmX5OtZNZLjTHgFLxKGl8zuNjBVozcccYnHBcEw==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -171,11 +187,11 @@
       }
     },
     "@aws-sdk/chunked-blob-reader-native": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-1.0.0-rc.8.tgz",
-      "integrity": "sha512-0LIjlX9QueugfuHfTh45hK+gxSo4aKbcaRy+iM7QICl4NGGWMu6YJ7GiLJo5lkeu4Y55ir9yq1KZ/x5LHePVtg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.0.0.tgz",
+      "integrity": "sha512-AveoLJ+OXctID0GZJ+pM9aLO43yp8GQvt4TgFVE3tNAq5hOkQ5uSe2Uzj6KwBUUrSnaVDYPaS7FoeRbXeHwpfw==",
       "requires": {
-        "@aws-sdk/util-base64-browser": "1.0.0-rc.8",
+        "@aws-sdk/util-base64-browser": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -187,63 +203,63 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-1.0.0-rc.10.tgz",
-      "integrity": "sha512-dwoERl2xe1tfcwV9F+jcLzOOmoCsv2JtcQTKzg+HtsEON45m1Mx5SkRe5nAvh1b7xDz9/XwZjb8+WN5YoBcrqw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.0.0.tgz",
+      "integrity": "sha512-IqwIvvAgEJl2O5nF+qCmsTLGhFornLdbBd31kgHjgjULM4Ocx1nL7nxi3vKsRDVqTvJESSh4puJVUkjNYpWlDg==",
       "requires": {
         "@aws-crypto/sha256-browser": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.0.0",
-        "@aws-sdk/config-resolver": "1.0.0-rc.10",
-        "@aws-sdk/credential-provider-node": "1.0.0-rc.10",
-        "@aws-sdk/eventstream-serde-browser": "1.0.0-rc.10",
-        "@aws-sdk/eventstream-serde-config-resolver": "1.0.0-rc.10",
-        "@aws-sdk/eventstream-serde-node": "1.0.0-rc.10",
-        "@aws-sdk/fetch-http-handler": "1.0.0-rc.10",
-        "@aws-sdk/hash-blob-browser": "1.0.0-rc.10",
-        "@aws-sdk/hash-node": "1.0.0-rc.10",
-        "@aws-sdk/hash-stream-node": "1.0.0-rc.10",
-        "@aws-sdk/invalid-dependency": "1.0.0-rc.8",
-        "@aws-sdk/md5-js": "1.0.0-rc.10",
-        "@aws-sdk/middleware-apply-body-checksum": "1.0.0-rc.10",
-        "@aws-sdk/middleware-bucket-endpoint": "1.0.0-rc.10",
-        "@aws-sdk/middleware-content-length": "1.0.0-rc.10",
-        "@aws-sdk/middleware-expect-continue": "1.0.0-rc.10",
-        "@aws-sdk/middleware-host-header": "1.0.0-rc.10",
-        "@aws-sdk/middleware-location-constraint": "1.0.0-rc.10",
-        "@aws-sdk/middleware-logger": "1.0.0-rc.10",
-        "@aws-sdk/middleware-retry": "1.0.0-rc.10",
-        "@aws-sdk/middleware-sdk-s3": "1.0.0-rc.10",
-        "@aws-sdk/middleware-serde": "1.0.0-rc.10",
-        "@aws-sdk/middleware-signing": "1.0.0-rc.10",
-        "@aws-sdk/middleware-ssec": "1.0.0-rc.10",
-        "@aws-sdk/middleware-stack": "1.0.0-rc.10",
-        "@aws-sdk/middleware-user-agent": "1.0.0-rc.10",
-        "@aws-sdk/node-config-provider": "1.0.0-rc.10",
-        "@aws-sdk/node-http-handler": "1.0.0-rc.10",
-        "@aws-sdk/protocol-http": "1.0.0-rc.10",
-        "@aws-sdk/smithy-client": "1.0.0-rc.10",
-        "@aws-sdk/url-parser-browser": "1.0.0-rc.10",
-        "@aws-sdk/url-parser-node": "1.0.0-rc.10",
-        "@aws-sdk/util-base64-browser": "1.0.0-rc.8",
-        "@aws-sdk/util-base64-node": "1.0.0-rc.8",
-        "@aws-sdk/util-body-length-browser": "1.0.0-rc.8",
-        "@aws-sdk/util-body-length-node": "1.0.0-rc.8",
-        "@aws-sdk/util-user-agent-browser": "1.0.0-rc.10",
-        "@aws-sdk/util-user-agent-node": "1.0.0-rc.10",
-        "@aws-sdk/util-utf8-browser": "1.0.0-rc.8",
-        "@aws-sdk/util-utf8-node": "1.0.0-rc.8",
-        "@aws-sdk/util-waiter": "1.0.0-rc.10",
-        "@aws-sdk/xml-builder": "1.0.0-rc.8",
+        "@aws-sdk/config-resolver": "3.0.0",
+        "@aws-sdk/credential-provider-node": "3.0.0",
+        "@aws-sdk/eventstream-serde-browser": "3.0.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.0.0",
+        "@aws-sdk/eventstream-serde-node": "3.0.0",
+        "@aws-sdk/fetch-http-handler": "3.0.0",
+        "@aws-sdk/hash-blob-browser": "3.0.0",
+        "@aws-sdk/hash-node": "3.0.0",
+        "@aws-sdk/hash-stream-node": "3.0.0",
+        "@aws-sdk/invalid-dependency": "3.0.0",
+        "@aws-sdk/md5-js": "3.0.0",
+        "@aws-sdk/middleware-apply-body-checksum": "3.0.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.0.0",
+        "@aws-sdk/middleware-content-length": "3.0.0",
+        "@aws-sdk/middleware-expect-continue": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.0.0",
+        "@aws-sdk/middleware-location-constraint": "3.0.0",
+        "@aws-sdk/middleware-logger": "3.0.0",
+        "@aws-sdk/middleware-retry": "3.0.0",
+        "@aws-sdk/middleware-sdk-s3": "3.0.0",
+        "@aws-sdk/middleware-serde": "3.0.0",
+        "@aws-sdk/middleware-signing": "3.0.0",
+        "@aws-sdk/middleware-ssec": "3.0.0",
+        "@aws-sdk/middleware-stack": "3.0.0",
+        "@aws-sdk/middleware-user-agent": "3.0.0",
+        "@aws-sdk/node-config-provider": "3.0.0",
+        "@aws-sdk/node-http-handler": "3.0.0",
+        "@aws-sdk/protocol-http": "3.0.0",
+        "@aws-sdk/smithy-client": "3.0.0",
+        "@aws-sdk/url-parser-browser": "3.0.0",
+        "@aws-sdk/url-parser-node": "3.0.0",
+        "@aws-sdk/util-base64-browser": "3.0.0",
+        "@aws-sdk/util-base64-node": "3.0.0",
+        "@aws-sdk/util-body-length-browser": "3.0.0",
+        "@aws-sdk/util-body-length-node": "3.0.0",
+        "@aws-sdk/util-user-agent-browser": "3.0.0",
+        "@aws-sdk/util-user-agent-node": "3.0.0",
+        "@aws-sdk/util-utf8-browser": "3.0.0",
+        "@aws-sdk/util-utf8-node": "3.0.0",
+        "@aws-sdk/util-waiter": "3.0.0",
+        "@aws-sdk/xml-builder": "3.0.0",
         "fast-xml-parser": "^3.16.0",
         "tslib": "^2.0.0"
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Z5Rc/QAyUrtRhOmhLAgGlFG3li2ihxkClDkbX24z8QxU5M9D3SGu+Wyur2nHX9G6ssgNkOcKfiy+H4dSPQCV8g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.0.0.tgz",
+      "integrity": "sha512-UGLud2uYwN1XOXX0xzSLoCcTrOkBIKIo1Ls0mN0dEryAQlFr2plR52Ze8OdjojXt49ZIrmb4WmPNFfszjwmkdA==",
       "requires": {
-        "@aws-sdk/signature-v4": "1.0.0-rc.10",
+        "@aws-sdk/signature-v4": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -255,11 +271,11 @@
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-1.0.0-rc.10.tgz",
-      "integrity": "sha512-robMjRq5pO3grBbzpC8hNHkjTut57OhbneDAvgN8FAabjcDf1ppufyMdPDbBrIM2omcbqUc6LN1GMS3BMlx1Gg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.0.0.tgz",
+      "integrity": "sha512-LzV08Cvwipfrf3POdKENFFN+0Gc1d/tlS+mJoym81yULUb8HE9RDGic5uvzRuv1ylWm2X/uAEtQjPlbzl3Tatg==",
       "requires": {
-        "@aws-sdk/property-provider": "1.0.0-rc.10",
+        "@aws-sdk/property-provider": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -271,11 +287,11 @@
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-1.0.0-rc.10.tgz",
-      "integrity": "sha512-yTZSNIANwoJIkRWx9vGJ7v+UiMa/e/Rhj1TPTRzUEw8vxTJ6laDa+aJpm6vVSVBXJpZwtYmCzwrTx6Flw5H3Sw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.0.0.tgz",
+      "integrity": "sha512-6lKQ1Z+c0VZgd1QILiRKY/28/vwG1IeSAX1NIDR8wFacbo8y+2b9dGg40fjw2MwSBPOyMHE3hkNJJ1BZrHZpSg==",
       "requires": {
-        "@aws-sdk/property-provider": "1.0.0-rc.10",
+        "@aws-sdk/property-provider": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -287,12 +303,12 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-1.0.0-rc.10.tgz",
-      "integrity": "sha512-LDsBUgW1xcv9P2VYuTq+A1NiG3snw0OxLvOxezDVQ35vtyo5LAnqSGQtxt3QrwykQpOs8fuVhtJg7jTy4vNarg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.0.0.tgz",
+      "integrity": "sha512-/M4MxULEPQtUqTrYB825ZVnwWdrrgVB9WmbPl9Zo8urmEDRN5+iPhYpCClpbbb02Y5KXdfa3sl5VZYny190E7A==",
       "requires": {
-        "@aws-sdk/property-provider": "1.0.0-rc.10",
-        "@aws-sdk/shared-ini-file-loader": "1.0.0-rc.9",
+        "@aws-sdk/property-provider": "3.0.0",
+        "@aws-sdk/shared-ini-file-loader": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -304,15 +320,15 @@
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-1.0.0-rc.10.tgz",
-      "integrity": "sha512-lZfHzcNYIYDVaNzKZB0NUa8yxgzPzNQIJNx7zkNLRo+IJWHv8LOLUDKL99tDz4ubEQQbJHPIdtoPpixrYLzl4w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.0.0.tgz",
+      "integrity": "sha512-NUvIWY5+K5nb5KxZFFvUkKtL33QwaQ78S43nhR5u/kMwCuB0Bbzzcpqtz+zcsMkZNNUtNOwMeZnP/4RiXuohbA==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "1.0.0-rc.10",
-        "@aws-sdk/credential-provider-imds": "1.0.0-rc.10",
-        "@aws-sdk/credential-provider-ini": "1.0.0-rc.10",
-        "@aws-sdk/credential-provider-process": "1.0.0-rc.10",
-        "@aws-sdk/property-provider": "1.0.0-rc.10",
+        "@aws-sdk/credential-provider-env": "3.0.0",
+        "@aws-sdk/credential-provider-imds": "3.0.0",
+        "@aws-sdk/credential-provider-ini": "3.0.0",
+        "@aws-sdk/credential-provider-process": "3.0.0",
+        "@aws-sdk/property-provider": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -324,13 +340,13 @@
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-1.0.0-rc.10.tgz",
-      "integrity": "sha512-MjmgtgaRIz3ob+wYbgytNUBzVtwrgJoPJHOd1I56H/Y4rQD/lDb2xqxiFYu+KPzCMW6R4PtrIcFeOiiFtqctPg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.0.0.tgz",
+      "integrity": "sha512-s5PFEufIRILR8rIvDIDqgk2nwCsqvN64j/Opj2gv2xgS6nqSWwr6oDHN67qru4haah7NQ19l7tP5oxcdVL820w==",
       "requires": {
-        "@aws-sdk/credential-provider-ini": "1.0.0-rc.10",
-        "@aws-sdk/property-provider": "1.0.0-rc.10",
-        "@aws-sdk/shared-ini-file-loader": "1.0.0-rc.9",
+        "@aws-sdk/credential-provider-ini": "3.0.0",
+        "@aws-sdk/property-provider": "3.0.0",
+        "@aws-sdk/shared-ini-file-loader": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -342,12 +358,12 @@
       }
     },
     "@aws-sdk/eventstream-marshaller": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-1.0.0-rc.10.tgz",
-      "integrity": "sha512-UNVmo9gGkmYULhyZjkkiwAc2mMsXxVprnu8uurvRTsqzh8E7oL9UV2jp0tpCpJ3l64WtWIMQXH65Kf0ZKOXmAw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.0.0.tgz",
+      "integrity": "sha512-mxAntbrX5KJGKD8kpTnAZs6WgkPrxU3TFNUj3wm018K0XEubrmim71pWZZkif1KXdF/XCvW0m0Nq2VlLDFYCyA==",
       "requires": {
         "@aws-crypto/crc32": "^1.0.0",
-        "@aws-sdk/util-hex-encoding": "1.0.0-rc.8",
+        "@aws-sdk/util-hex-encoding": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -359,12 +375,12 @@
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-1.0.0-rc.10.tgz",
-      "integrity": "sha512-FPaPjMJM1VArkdg2CvbxgaqVAuz0o3cJ7wIg1ahCu/y7hyrg8VIlpDvmRFOMZYpsVEygz70Z9GqBBQoU/p4sXg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.0.0.tgz",
+      "integrity": "sha512-C79h0bbPkIwJHVzSLJOIW2shX5+FMpYFzWmHs5B29vp3LjwxDhl+Ju1NmSeC3mpsVVnue1hLr/n+dHO/aQtSWw==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "1.0.0-rc.10",
-        "@aws-sdk/eventstream-serde-universal": "1.0.0-rc.10",
+        "@aws-sdk/eventstream-marshaller": "3.0.0",
+        "@aws-sdk/eventstream-serde-universal": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -376,9 +392,9 @@
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-1.0.0-rc.10.tgz",
-      "integrity": "sha512-JAqaywsPLOs02kDGMjfNiqgZxawdOfUHCcKqK4tKUbceXQcDjge6u0W0O/5qDkoMRAN8g3w8m67NUoCodBMt9g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.0.tgz",
+      "integrity": "sha512-BNLS+OpY//1bwgOMYhvu2uyXayJOT24uiSfK1hEpjyYfyvMSgT9CCIkNv6ZElzY1NpwoC7mbyHIq2aSHW8kq8w==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -391,12 +407,12 @@
       }
     },
     "@aws-sdk/eventstream-serde-node": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-1.0.0-rc.10.tgz",
-      "integrity": "sha512-wdBgjIbMmq3NXsdl3z7oiOzeJ0Xu4/AHmcKt4re/jby19Y/c0Eu+saXTii5Xs19jqCKqG0zgJXbPHcFz6JSKXg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.0.0.tgz",
+      "integrity": "sha512-jt9UnXRFaxNhLnX17+A8G1wg5xlLMWvRSZDidVY+mYiSpk5UG7rGVgzViGU7ORCmDdZOyDSjUay+2hII22rr/w==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "1.0.0-rc.10",
-        "@aws-sdk/eventstream-serde-universal": "1.0.0-rc.10",
+        "@aws-sdk/eventstream-marshaller": "3.0.0",
+        "@aws-sdk/eventstream-serde-universal": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -408,11 +424,11 @@
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-1.0.0-rc.10.tgz",
-      "integrity": "sha512-R1dJ79mkKRJISjX8yGju1+PeTOQBECZLhYqhANS0YLzrVgt18y7yHu1BNBfcxCNs1ZyWir2BpYo3pA/Yuk7wLg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.0.0.tgz",
+      "integrity": "sha512-xW6GAsDtwFT5qJosm9zv8H/Ek3O7yRkkRlblN5adhK7VJ2ZOZRSa+1834AVHow1FatIqkO+PP5dBnOUgVCrocw==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "1.0.0-rc.10",
+        "@aws-sdk/eventstream-marshaller": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -424,13 +440,13 @@
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-1.0.0-rc.10.tgz",
-      "integrity": "sha512-bxuDqnC6iN/jrvU0hWEPTk3FsWtkcZ2EJuL83bXeRph++P/JXYsjOlFMjaFvplTXVX8vhc9SULq2o5h3xlN79Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.0.0.tgz",
+      "integrity": "sha512-2UX5e2YP+tv8CujNZs4+kU9aSVhAZn8HsOPM9uWFSHoEJkLsaetCaxYOzt9swag3OYnTffpVrqh4b9N2yPnUCQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "1.0.0-rc.10",
-        "@aws-sdk/querystring-builder": "1.0.0-rc.10",
-        "@aws-sdk/util-base64-browser": "1.0.0-rc.8",
+        "@aws-sdk/protocol-http": "3.0.0",
+        "@aws-sdk/querystring-builder": "3.0.0",
+        "@aws-sdk/util-base64-browser": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -442,12 +458,12 @@
       }
     },
     "@aws-sdk/hash-blob-browser": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-1.0.0-rc.10.tgz",
-      "integrity": "sha512-2jUSE+FlFlVA6hZA3ATz0XDwypMNs2i17kfgmp3oDLS3jJoTEmVeEMHyGmd23VpIQduO0/aIx3i5Qc6ukzwqVg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.0.0.tgz",
+      "integrity": "sha512-8Jl6etn2lGND9kP3bGgwpSOjyTdIcE4ynY4rc8ogvjFKbxnmUNtDmylUSNfFv6+dvi0861I+9H7M7zxoI1I2dw==",
       "requires": {
-        "@aws-sdk/chunked-blob-reader": "1.0.0-rc.8",
-        "@aws-sdk/chunked-blob-reader-native": "1.0.0-rc.8",
+        "@aws-sdk/chunked-blob-reader": "3.0.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -459,11 +475,11 @@
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-1.0.0-rc.10.tgz",
-      "integrity": "sha512-HaDZ17h8awZSZu6aqjygLD3mYFIbQnrztrlz3GWeSN3P4yWhSXsppv3o3LDIlMAQFwleuwUP8Ux9Nl1qzjtSvQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.0.0.tgz",
+      "integrity": "sha512-AMKT/Tg5AmJPBA2yyERf0pA8T7+Pr9Ss1ZBYN8QGc3mLtH168uHdi85pu/5fv8+ubEO6NVyPD6MAibgWWIQ0rw==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "1.0.0-rc.8",
+        "@aws-sdk/util-buffer-from": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -475,9 +491,9 @@
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Gd/im5B0u/btT/9xbmp3reM4acNbOFFgdMaAEyvN57dQel6LCOb8AnYkFRfQIelKUI97LSlrpHJmf7RWGeI2rA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.0.0.tgz",
+      "integrity": "sha512-0WzkHMPvlbk2Wz710OKZotjD1rwCHvSFtftpCrt8cZZpM2i7qVBO8D2Z2Vj+DSvFhFsU1o/Ro/dPRmGXkHrGyg==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -490,9 +506,9 @@
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-1.0.0-rc.8.tgz",
-      "integrity": "sha512-T7fMj3y8tFVH+t9T9U9htXya8THjV0IzWvec16CVYOtThRdj5RAN9XXkW6odgyJVz18mVWSSjzgqCwa0W0FIkQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.0.0.tgz",
+      "integrity": "sha512-lAP5OpkxPB0a3sscfqhFOeLaCVIUvi0zSuLdoCXfqGjl2SYgq27U9IsFM2qHjAGrg1VrqhRWxi+7XzKNnI0E+Q==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -505,9 +521,9 @@
       }
     },
     "@aws-sdk/is-array-buffer": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-1.0.0-rc.8.tgz",
-      "integrity": "sha512-qink0kc2Px0wPY3v2hC5uvQFYfiFJKDkjcDw7IFCyangGrcIwgOjwzSVnf/cRvdDyyy3l62EXPCdtitnu9MmkA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-XEDXuZKHFDlBfeFU02b1bjN5KY2+7j+owXebe9A5qGKT2istaoY0TASidibJVd2qdj38zf+e8xKXvW/Akiha2Q==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -520,11 +536,11 @@
       }
     },
     "@aws-sdk/md5-js": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-1.0.0-rc.10.tgz",
-      "integrity": "sha512-CEe8al8RxjbKlkHVGe4i3LhcVjMDdsoqyUKWR/aSfFnf4RC3K/xXfyjXOW66K9bHisbakcctiqTtLBoLuTlppQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.0.0.tgz",
+      "integrity": "sha512-9OAUcOkhfjHQcJjPEfz5vG3Fbc7VyHKbt0gl5suIfURFmKUKQ+OduCwfafCf0m6j7IGN2+hm652wNGo/k2Bhzw==",
       "requires": {
-        "@aws-sdk/util-utf8-browser": "1.0.0-rc.8",
+        "@aws-sdk/util-utf8-browser": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -536,12 +552,12 @@
       }
     },
     "@aws-sdk/middleware-apply-body-checksum": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-1.0.0-rc.10.tgz",
-      "integrity": "sha512-aaCeQZEe/ERZYptAhyc2vkDWQSJqH9dDQfWVknncxgF21hnGRlSyXqzzAM9/RTPbtGWqktxcis1cZ7xAtQzbDw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.0.0.tgz",
+      "integrity": "sha512-XvyYOj8C4Hc0n8/H2LfLisn9o3NpZtb6iOVmj0pIbPAserkbzHWozqIVrjgiMueB8HKE+lIm1xJCzb7DQqQwqQ==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "1.0.0-rc.8",
-        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "@aws-sdk/is-array-buffer": "3.0.0",
+        "@aws-sdk/protocol-http": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -553,12 +569,12 @@
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-1.0.0-rc.10.tgz",
-      "integrity": "sha512-nCGjzbB2ENoH/RMoKboiglYBn6G3ib1pb08Jqnshr9EicaCz1A9KrJtVdqsPnkvzB8w1JRPrmCNJuC3hC1Ueww==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.0.0.tgz",
+      "integrity": "sha512-JspvMQxgBivwJTMDfuuZwGOvucVfS25D7LN7LNuAbO6AW0gWXyVULEkOppKJcR/XkqMSyqLIaXnA6YG/+c3fMQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "1.0.0-rc.10",
-        "@aws-sdk/util-arn-parser": "1.0.0-rc.8",
+        "@aws-sdk/protocol-http": "3.0.0",
+        "@aws-sdk/util-arn-parser": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -570,11 +586,11 @@
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-1.0.0-rc.10.tgz",
-      "integrity": "sha512-u1mhrg8joX/YZnqwicK5IxRRGnKGNpnSyY3h7iLa1gh2s2UCsMQi0hL36e3TP2v0LjhpW+nAHUrd47lxppkSig==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.0.0.tgz",
+      "integrity": "sha512-AVpoUMF3iBAnZ/T6F55PLjI1HfNSYlcG2dvoDkP823UrQf4J/yNgOZ5CVoz3yaz/8Lp6ZkUF+I4QnJIPNaFllg==",
       "requires": {
-        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "@aws-sdk/protocol-http": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -586,12 +602,12 @@
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-1.0.0-rc.10.tgz",
-      "integrity": "sha512-aUbgwbjfnY7CI9nU36yLdjI2fmaN0l6fjPOQH5HapcilyrMG+LQo3WMsDMCYl//weJptse20Tptv6eSTNci76w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.0.0.tgz",
+      "integrity": "sha512-k+n3VpE7l8PH1bV6ROKIWeZMPvlEx/yvpOtE4sH6smnqKlAJ+yRogD8XxBOzvf2fRhO33M2NJR3xl1UHfLMPrQ==",
       "requires": {
-        "@aws-sdk/middleware-header-default": "1.0.0-rc.10",
-        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "@aws-sdk/middleware-header-default": "3.0.0",
+        "@aws-sdk/protocol-http": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -603,11 +619,11 @@
       }
     },
     "@aws-sdk/middleware-header-default": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-1.0.0-rc.10.tgz",
-      "integrity": "sha512-9W0Kr2nJvvMhKA8JDcnugPo7/LANnB/Io3vTPSSajaoR6Lnxcb1SaLAXJUjdH+A4+MG8QIfCbOB3bu1KmoAkEw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.0.0.tgz",
+      "integrity": "sha512-aTj8+7gkzOv+RgKxvtWmd6F8V/3fsGsGMlXjcpniAlfXbkjHVhSVmsLStIs3llXHLUuOkaigLJe0hTskvPnY1w==",
       "requires": {
-        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "@aws-sdk/protocol-http": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -619,11 +635,11 @@
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-1.0.0-rc.10.tgz",
-      "integrity": "sha512-/YC/XJKKUDvYDHRH726F1aZsdKQ3sjT3RVwdPXiHeECYiNpQ+0uUQ7n81CoySoRTNuHLTgGHh6ctAcJUU1Xj+g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.0.0.tgz",
+      "integrity": "sha512-/SjdWI/45aWvOPu8fV+7POpSK/ujHucq15BJfWfRrjBpT7i3n6qlpolGnNLJnexMiZYrhK+tWvSDUTK1KRRQVw==",
       "requires": {
-        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "@aws-sdk/protocol-http": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -635,9 +651,9 @@
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-1.0.0-rc.10.tgz",
-      "integrity": "sha512-nF8zII2aT/KrtljOEfyKA2Qfmy9zRwQP9nljzsRq8zn4uB8+dGnDgc+BdyavAErIoB+uf/0iswrYSPlSlEy4Wg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.0.0.tgz",
+      "integrity": "sha512-P5htyuVx0lT4UOMKeMgAp+Bn4dKkOJsVjvLv/buK5dYf32mMyzI/gpmete43PcGSG1xve7wxgFNebWNpC2DpEg==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -650,9 +666,9 @@
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-1.0.0-rc.10.tgz",
-      "integrity": "sha512-xO380+N1KfRXudcOYgR1rUZp1blxuYUADIvYXF6xrE2K5konuynEChLlzHy0cmtqoHgvGDmVdhDbkDdlw7MB0g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.0.0.tgz",
+      "integrity": "sha512-RKXrwBuipom98prNE9bwv8k9tntvXc/YxJ1wgD8F4LgXCTO6X3xh7SYTQyC/Ih/kK0qUpW00uYPvLbu9tpmkeA==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -665,12 +681,12 @@
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-1.0.0-rc.10.tgz",
-      "integrity": "sha512-24ycZ/2iqTk1G7/YrLJbbhRA2vV+SosTKf63oEf1r7DPYVN/q6YMMXo0XuCmai6mGrtV6JEclSivBHmWo1zAYg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.0.0.tgz",
+      "integrity": "sha512-ZwqMYQcEi3kYjQiDgiBdmkyKuvami8hE6TbQvFT2/Kyelrf78rXpPD03tOyEJnsmo1ohHf0aYCavepg46kwuPw==",
       "requires": {
-        "@aws-sdk/protocol-http": "1.0.0-rc.10",
-        "@aws-sdk/service-error-classification": "1.0.0-rc.10",
+        "@aws-sdk/protocol-http": "3.0.0",
+        "@aws-sdk/service-error-classification": "3.0.0",
         "react-native-get-random-values": "^1.4.0",
         "tslib": "^1.8.0",
         "uuid": "^3.0.0"
@@ -689,12 +705,12 @@
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-1.0.0-rc.10.tgz",
-      "integrity": "sha512-xYs3JX6Ll1Wr+HQSJK8qlvRTnsZ41fOD5EZRSOiisW9A3Kc4U+P3ELNWYCJhIGuZMgDJQNUMkjNP+MFiquJHCg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.0.0.tgz",
+      "integrity": "sha512-9EcThJaQ8h1lYaDR+Q7kMtYJRCxak0DYdeh2nEmCy1ic6Nak7ZNkaTkvGJdFJD3M1LL9pzAKlxEpgIrpPSfVTw==",
       "requires": {
-        "@aws-sdk/protocol-http": "1.0.0-rc.10",
-        "@aws-sdk/util-arn-parser": "1.0.0-rc.8",
+        "@aws-sdk/protocol-http": "3.0.0",
+        "@aws-sdk/util-arn-parser": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -706,9 +722,9 @@
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-1.0.0-rc.10.tgz",
-      "integrity": "sha512-e5MMxJT4THdWYXLvsDFwwEBSqO1iCPiSeVCbczLe2VwVaDkhJlUtHXfJjy31wZYAubS/AJH+YPO6JFaWxj7DOQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.0.0.tgz",
+      "integrity": "sha512-QY11ZXOkOc59+xayTCXdZxqzrjtI3sT9IWBy6/LyylAN+y7xtuCwiCvXf+YkiYpBORI5ZNC4Mjwuy0Nf0rkoIg==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -721,12 +737,12 @@
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Ohyj8Ob0yHkCi8YxG5IZ2va/5daWXHtJD90otUOWu4HdHAAJ1xtkFzJUVO1E1LZUsuLcR2WDuGuGnznOMbSVmw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.0.0.tgz",
+      "integrity": "sha512-8lj42dCbGQkgx7EMienpXLTbko0U7TAsmpRIYT6w0wEjCq0O77cuQYJYacdu163adlZnw5gAzlSlR0OXNb/SGg==",
       "requires": {
-        "@aws-sdk/protocol-http": "1.0.0-rc.10",
-        "@aws-sdk/signature-v4": "1.0.0-rc.10",
+        "@aws-sdk/protocol-http": "3.0.0",
+        "@aws-sdk/signature-v4": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -738,9 +754,9 @@
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-1.0.0-rc.10.tgz",
-      "integrity": "sha512-GZNZn1bYJrxDwpu1D3EkpbiuPuxy/37Ue4t7187/e0vvqM2gxNF6bxinX4K5Z3xi+c5Px9PbLylZjzVH7tBoEQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.0.0.tgz",
+      "integrity": "sha512-ILnzIkllg2uCDwg0Vnj+mTnTLjCqxEl/PReUyy7KdPPKW92q7vOcn/miB2Fth6NIST7zne69REhsdNcyM2X/tA==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -753,9 +769,9 @@
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-1.0.0-rc.10.tgz",
-      "integrity": "sha512-3C36t4wFTLgBkmLOiaHCUoysIUIKjBSCGVVvnmE8S4SCGhBkPBjKcHMPjA94ru8/D+dSggSSZxixeCCa1KjePQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.0.0.tgz",
+      "integrity": "sha512-ULTe6G1bIk8OuK20lq+v5AOPjszRnfXt/pY4C3KxKLYOq/zn6CSOAKWbMM5QZEGV6y9T1ISWgFcdsnBoMBjRlw==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -768,11 +784,11 @@
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-1.0.0-rc.10.tgz",
-      "integrity": "sha512-pBGSlqParM0pv5FmSl6ulhJPwmcA2ZagjYdoNdsb9C1xh8vWTHtlIYioRyIWjJYK4y3g3mwrmE7577OAZMIgtw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.0.0.tgz",
+      "integrity": "sha512-x7YE5JtILf6Q8paizfnwHvypXY5nXGT1akPUQk2L65mL+Hnc6DbTLjkRsPZ8yRHcs86fWaNescflXQ4itttK9Q==",
       "requires": {
-        "@aws-sdk/protocol-http": "1.0.0-rc.10",
+        "@aws-sdk/protocol-http": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -784,12 +800,12 @@
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-1.0.0-rc.10.tgz",
-      "integrity": "sha512-gdp9Zz/m4F+fTTn7CmZQnY0fNJaSFElHSUVA1L8n2F+3t9TRPJCeymPHO6cTM2o3d29FCcCBN79JT2UhZ8x4Yg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.0.0.tgz",
+      "integrity": "sha512-UD3W0djDC6z6mNbu0JI54pujzowWU+9y9yvLJDfNeUwBd5rnOQfLqaE9z6UGBtdKZbieH18wWrCK10JF7cr6uQ==",
       "requires": {
-        "@aws-sdk/property-provider": "1.0.0-rc.10",
-        "@aws-sdk/shared-ini-file-loader": "1.0.0-rc.9",
+        "@aws-sdk/property-provider": "3.0.0",
+        "@aws-sdk/shared-ini-file-loader": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -801,13 +817,13 @@
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-1.0.0-rc.10.tgz",
-      "integrity": "sha512-+Sk4gUl9sRSburG0uUdEbJ2uiQcswBIuCqrCtNw4oHqc9OTcXg7N5OtHZQFjl0YHUPQ5eB1DVwKWqtdpD2fCRA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.0.0.tgz",
+      "integrity": "sha512-KlrW45M/MQEu+ZsDEqrrHI1lLnURLdHtC8yYoLF5XuBGRfpm35KaNZBqht8x+sVfZUJq9qfHhhoe+rLrqNXe5g==",
       "requires": {
-        "@aws-sdk/abort-controller": "1.0.0-rc.10",
-        "@aws-sdk/protocol-http": "1.0.0-rc.10",
-        "@aws-sdk/querystring-builder": "1.0.0-rc.10",
+        "@aws-sdk/abort-controller": "3.0.0",
+        "@aws-sdk/protocol-http": "3.0.0",
+        "@aws-sdk/querystring-builder": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -819,9 +835,9 @@
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Vqz/RkmNjS2YCNK+mrdWZALDHKnPdgW6eAFibge0F9xHv+6PPmHFs0/ggJX8owZozQCbNQtsJ+up4kzF1q4Xxg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.0.0.tgz",
+      "integrity": "sha512-XgTXGTjHkzpU/YlscY/DCstfrdv3xd+qE4kbKmIj1dEVn7Y4mbIju6h0wSATajW1kOdaXiq3gS/RbqIBOpgdiA==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -834,9 +850,9 @@
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-1.0.0-rc.10.tgz",
-      "integrity": "sha512-ON7GR9HEqsx2tZD2UnPqPVlDFADiTBMm6BnUQlxOIM7q0NEvKLz9ZaKxwgM5Hq5pOLg/uGAMpD1PJAUXGd6K+w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.0.0.tgz",
+      "integrity": "sha512-fqSdd0Euv5ETc8C2qp0sCoC0YFNRvyBWbizl3zFWUr/pAW7KIMiSPByO3fdelJMYvQsQ093+AI3tGSl4qFvVZw==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -849,11 +865,11 @@
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Og6s3NfZcxez/77vD0uC34HRcp9e0uIxzJcMhXdL9C0y/eRcIAZrH0ozjfwFSAulTeVuR6OV4sXz9Ucv7grh3g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.0.0.tgz",
+      "integrity": "sha512-qPm+1vRCRQOqxBvBx/moecyNKLxoQnNVawSG6jrVU5RRNebFeJd/Xh1+Me1c+feWx9YeR0+sAq4ELewDCZOy0Q==",
       "requires": {
-        "@aws-sdk/util-uri-escape": "1.0.0-rc.8",
+        "@aws-sdk/util-uri-escape": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -865,9 +881,9 @@
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-1.0.0-rc.10.tgz",
-      "integrity": "sha512-91A5Hp1MUdxOLMy02U21lOX7fFbjGY4DgSJ84OsOX0BVAiGJufyFEHG2pDAjAJSuSDgbgrlrW3uk5cNqkyqbJw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.0.0.tgz",
+      "integrity": "sha512-uZFw1V57rebnGobE5fyBaGn72bulDQHpZgEBX/l9PBs7z2wBogaz9hsqxn0h5+hWbnyNE2odoFGtk3ZdHm9VnQ==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -880,14 +896,14 @@
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-1.0.0-rc.10.tgz",
-      "integrity": "sha512-GIkVdPbNYujnMWS/VGjhnVL5bmdD+Qr4Ov2Fpd5z5+NwIgvMP8W60I+xb8GQsebBAOVg+B2btJikv3jPME/jgA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.0.0.tgz",
+      "integrity": "sha512-Pw73nb1E195S8GaIHH+69ITYB7KVo5I6UrrlwZNfSqtB30A5Tj5K/p5HKjJZln9Th3+ESfkf4ajg+j7KkJ/0dw=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-1.0.0-rc.9.tgz",
-      "integrity": "sha512-Nyw4/PGMxm0VPEI3d+Aj0cRz/q/DSM83EyYTzjT0lbE7hgdNT1Y8NljkxfxTa2uQQLjDZUtmkIfVOJ42/HriMw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.0.0.tgz",
+      "integrity": "sha512-zcuyi3O1vaeKDIHVljGY3v6xAwZrz54EnjQWIc37OyXXY611NmqPMrW5IoG3VCXLwZSTxGuqjWX5IhHRt6xOtw==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -900,13 +916,13 @@
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-1.0.0-rc.10.tgz",
-      "integrity": "sha512-qekaz/KHDt3gquk4t4A8AbhJfdo86OrKIgh5RAIHUw/5v3tsojh6Z3GLsYpf1+YrmG8HGXzv4g2sdN18n1tl5w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.0.0.tgz",
+      "integrity": "sha512-ocstLMrDP2BO0znDHaboAYQB6PosEUWbr07c3IUmV5Vij8Xc/cODQusVSmKdLvEE4qwMaK/yZ4n9sSe8uuZqqg==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "1.0.0-rc.8",
-        "@aws-sdk/util-hex-encoding": "1.0.0-rc.8",
-        "@aws-sdk/util-uri-escape": "1.0.0-rc.8",
+        "@aws-sdk/is-array-buffer": "3.0.0",
+        "@aws-sdk/util-hex-encoding": "3.0.0",
+        "@aws-sdk/util-uri-escape": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -918,11 +934,11 @@
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-1.0.0-rc.10.tgz",
-      "integrity": "sha512-xpV5DlOSCORf0pLR/tvRa8QF4Bdf3lBMVfCbfWYOaONUw93oulKYWnFlSHh4MK3JNDox4hBYf/owu3SBTkIAhA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.0.0.tgz",
+      "integrity": "sha512-qT7v27KHNBh6nUH7rsk4EcRKJEahdD1eWUrR25fJ+vZQIDEe+reNKDIPalR60plrjvfrCiFkxL21pjq3KA1JVQ==",
       "requires": {
-        "@aws-sdk/middleware-stack": "1.0.0-rc.10",
+        "@aws-sdk/middleware-stack": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -939,11 +955,11 @@
       "integrity": "sha512-9gwhYnkTNuYZ+etCtM4T8gjpZ0SWSXbzQxY34UjSS+dt3C/UnbX0J22tMahp/9Z1yCa9pihtXrkD+nO2xn7nVQ=="
     },
     "@aws-sdk/url-parser-browser": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-browser/-/url-parser-browser-1.0.0-rc.10.tgz",
-      "integrity": "sha512-1KiynhAbGr/bAkNlbx0JHXyJJj6ndcHzQo1RHK0lJazObWSiUjs+CSHDdMB4RMI5mKTEzP5HBBH2B/1us4JNTQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-browser/-/url-parser-browser-3.0.0.tgz",
+      "integrity": "sha512-Y2GLy/G+AT5FnAU96BOT2GGqRCX9ZzokZucfPwFiPc6Y7GGqJqt4wSmPkg5hj6EKiPYBIEjZzqoS+0Q2RkqmpQ==",
       "requires": {
-        "@aws-sdk/querystring-parser": "1.0.0-rc.10",
+        "@aws-sdk/querystring-parser": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -955,11 +971,11 @@
       }
     },
     "@aws-sdk/url-parser-node": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-node/-/url-parser-node-1.0.0-rc.10.tgz",
-      "integrity": "sha512-GakSZZ/xMvw5JPQ8pLIhZ27IRO2b5Qb0iigknKQxjvx9WVDjS7FRUHZsG0Pct/gz0LuSmouQlCd2/458RbboOg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-node/-/url-parser-node-3.0.0.tgz",
+      "integrity": "sha512-3alAzkuY+CmQt89Q608dQ+VDCSzEc/MlgU+4P3O3Dk0xQqUGxQz3sErhyoY0d77jTY6bVU8H7SFvcwFCdO0NCg==",
       "requires": {
-        "@aws-sdk/querystring-parser": "1.0.0-rc.10",
+        "@aws-sdk/querystring-parser": "3.0.0",
         "tslib": "^1.8.0",
         "url": "^0.11.0"
       },
@@ -972,9 +988,9 @@
       }
     },
     "@aws-sdk/util-arn-parser": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-1.0.0-rc.8.tgz",
-      "integrity": "sha512-uIx9fAzM51eBexZ7jcczPQaF79L4ENUHqRUJL3AUzcsjK2NSXzTGvRZiS8EmAqqZH7kgttEchp2e35SXPSAaYw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.0.0.tgz",
+      "integrity": "sha512-srQjwEnavosPNRvTXhp+tv9tQ7+4tJTO5r8B5nWU1ApVQQrj1Y6NeVMobAI971Di2JslAXXlMWdZf4VuIy3NMg==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -987,9 +1003,9 @@
       }
     },
     "@aws-sdk/util-base64-browser": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-1.0.0-rc.8.tgz",
-      "integrity": "sha512-3cKuaOSM3PedrnROeqiWbRUN29XLDYHeiJg/JFM1IW1JxwW6mOM8upD4WqL13BUJwPax8MfaeG9xKCMZP0OaNA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.0.0.tgz",
+      "integrity": "sha512-1jtiaXdo3skMFGYNPAo5r8ttimakvfelu1LyoMH0S4Pddxk3+YKr3h8jzbLJzfm9avp1ollJakLZmGkkiNJVJA==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -1002,11 +1018,11 @@
       }
     },
     "@aws-sdk/util-base64-node": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-1.0.0-rc.8.tgz",
-      "integrity": "sha512-/RsrJYdNfXTEiAg9gYCB8w1lV7zHcaxDA0KMkvZGv5+NEjF40mKLb/oU71l3+42NJdR8+2iPJaWg5K1TxQp5tQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.0.0.tgz",
+      "integrity": "sha512-PgV179JbcAm+rTe02/F4YbhD9eTdZrx+PCyiDb6vX18MmY0pydsdXSmQZ9KbWbaj6Ony5bcLLtPEdalf6vu3Zw==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "1.0.0-rc.8",
+        "@aws-sdk/util-buffer-from": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -1018,9 +1034,9 @@
       }
     },
     "@aws-sdk/util-body-length-browser": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-1.0.0-rc.8.tgz",
-      "integrity": "sha512-wN0SMHTZUiCFEDSoi66ut9N6QX31Anfi/cus4Tz/1wvHJPJbMrxR1EgH1djfBg2Dtk6iGosrdb4uACdwkzatGQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-NV3vBGKa5k3bEzXlrSI444F/JZRfWtGRZl/D+Ve5KdseRv7KJbV3L8M62zswAmyxMYku1RyRENEZ1VnjNff5yg==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -1033,9 +1049,9 @@
       }
     },
     "@aws-sdk/util-body-length-node": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-1.0.0-rc.8.tgz",
-      "integrity": "sha512-QFx6no7MGmuBrs+Sf1AalJZKqczAR73wMccqmw7fJuRJWAqItp5NflOh2y6tjm5Q1PRP4hsLyGii1QIm8/NYSw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-zt9Jivz3rkeWOUkZFClXzHcX6tcPbTaYzKSZOMwi0H0IlhSM/yllDjLuj12VlBG9f9BarxGA1Mj1RAK2CvzsSA==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -1048,11 +1064,11 @@
       }
     },
     "@aws-sdk/util-buffer-from": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-1.0.0-rc.8.tgz",
-      "integrity": "sha512-NXIuqqkEsf15Qw7oJoChwGP+oO42+tJzjjgKcV+UVNmzwbXHn10XtmPwL7hgDTl2dj2xMrCoheraLKJ5jJUEFA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-Z/tU7/O0G2lYImMvAchCrPk2L8OmIs2pHi58kXEtHk/hxZXT1sJIZLErd3OFYaDFLaqOeEkebWB+jseBXJLv3Q==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "1.0.0-rc.8",
+        "@aws-sdk/is-array-buffer": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -1064,9 +1080,9 @@
       }
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-1.0.0-rc.8.tgz",
-      "integrity": "sha512-7tZgYNwHsvA/Tw7LDSSOXzacb6pbz3lv7xICVMP3MTuprj4MOZmjBg5nNpFp2zPd2xKDH5DhfNMvrex3cbS/tg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-bYWnM1I9vv1IhrCrcp6cEjqkJUAeheFFFUSM/VANMN8AgXzdjMeR8JNejnSB8Lw3Oi9LZ+uHV+cXHanW55qymw==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -1094,9 +1110,9 @@
       }
     },
     "@aws-sdk/util-uri-escape": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-1.0.0-rc.8.tgz",
-      "integrity": "sha512-nYXuNr5pB62FK1ZvhXx04A4NIfP2JZNHf/R3LMW2TQgYW/yH6mHde1f8lEUISc/Dnc336DNkxN7T30vaRUcvLg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-xl4ALVX/YbmFxg6NvmLv/TsPMxcizrmXvl0x79JhSRYU2cyvhgh2EuMrUzcitixgsYtdGqihWe3tj9Z8zXDRSg==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -1109,9 +1125,9 @@
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-1.0.0-rc.10.tgz",
-      "integrity": "sha512-nBN4auoCH9kbgo7CZG0k8MD4hjWx7vLzrrwpaKNzjNYC3UgeXCAey29ccexp1tv3hNnCvwtk43SGJkXa+7NLvw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.0.0.tgz",
+      "integrity": "sha512-ivveMLf7Op2b022buy3Uwy/ctEQyAGWjK/TgnYX4Hv8uvJREJURIXSeAvohT/dlhy54Mhd40nlr3eJY35BTpSw==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -1124,9 +1140,9 @@
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-1.0.0-rc.10.tgz",
-      "integrity": "sha512-x7E8c5ISflKDazSNix3S/2JPVImR01JT7re/xG5m+ZsqAHu842cnNMUtYpk0nXpgRRED+/j3Fyybqa2nrZOevQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.0.0.tgz",
+      "integrity": "sha512-tUjVOgidkbuUK+XSloYTX7P/dbpGdvYHKOmKAGp72fRikfLxGazJcNS7wJ5RalVErIoH5/C6e6EJI8azKubpHg==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -1139,9 +1155,9 @@
       }
     },
     "@aws-sdk/util-utf8-browser": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-rc.8.tgz",
-      "integrity": "sha512-clncPMJ23rxCIkZ9LoUC8SowwZGxWyN2TwRb0XvW/Cv9EavkRgRCOrCpneGyC326lqtMKx36onnpaSRHxErUYw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.0.0.tgz",
+      "integrity": "sha512-7vTn2KFOjUter7wwCjyQ+iJWvREOI8WAYyXSbD222dkY3VB/DAYFtMDErc4Sh4Onu2WPzdKJ6fnYwCpAxibHOQ==",
       "requires": {
         "tslib": "^1.8.0"
       },
@@ -1154,11 +1170,11 @@
       }
     },
     "@aws-sdk/util-utf8-node": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-1.0.0-rc.8.tgz",
-      "integrity": "sha512-7nu5Yk8agcK/y5X/CV9u7P8Q2OW6q+2vmuOpzNXDVM/KR3QX1g9PC1P0Isc4v74Q5t/hRkJxq2auIMJKZSAjDA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.0.0.tgz",
+      "integrity": "sha512-0pCFuWqABvv14dVTMQBWQh95CR2gCNQxu9aOOYr8GR37wqdgNvsSCzrmapydG4Q0FBNoTkqtx/7Nqdedb3+EXg==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "1.0.0-rc.8",
+        "@aws-sdk/util-buffer-from": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
@@ -1170,15 +1186,20 @@
       }
     },
     "@aws-sdk/util-waiter": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-1.0.0-rc.10.tgz",
-      "integrity": "sha512-dwF5bXgWG1VDTxyACzCY+Kfa3JlmA9vh2gbQGJURLdzHPdyJE+3UegCp7YbgOkOQj8OnvISC66usZaoWf8fqIQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.0.0.tgz",
+      "integrity": "sha512-Z2AYDLNVAsTdq5ImbrbrfM+/QopZIPXn36WNTNV4cAfUs8p5YmsdZyjlaSH1l4THru4e7ngqAm+Y5wJ5iqH0hg==",
       "requires": {
-        "@aws-sdk/abort-controller": "1.0.0-rc.10",
-        "@aws-sdk/types": "1.0.0-rc.10",
+        "@aws-sdk/abort-controller": "3.0.0",
+        "@aws-sdk/types": "3.0.0",
         "tslib": "^1.8.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.0.0.tgz",
+          "integrity": "sha512-D2sSHRZRw0ixox5+Dx7xPvTfMLZQzxJ/nWDP26FAl+c/i/402d0Y9acfDtUxfxPxCbVogZ3XgZXhjDY/RmMAjQ=="
+        },
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -1187,9 +1208,9 @@
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-1.0.0-rc.8.tgz",
-      "integrity": "sha512-8x4nbr4/N4NEpIs6WwbkNQdefQqZI9l3zLfs1a16E2RNEUWtM0RocU4OoA73yyGUZNmDjiZ3tFsx9aDMRe21bw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.0.0.tgz",
+      "integrity": "sha512-bExhgT1KH4JSBddcMNfQpVptfIBI707g55BC53kfs1csvfRgpgtzJYx96fhcvAXCDIkK98KBrwnpTCCoF6HMqA==",
       "requires": {
         "tslib": "^1.8.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,1171 +57,6 @@
         "symbol-observable": "2.0.3"
       }
     },
-    "@aws-crypto/crc32": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.0.0.tgz",
-      "integrity": "sha512-wr4EyCv3ZfLH3Sg7FErV6e/cLhpk9rUP/l5322y8PRgpQsItdieaLbtE4aDOR+dxl8U7BG9FIwWXH4TleTDZ9A==",
-      "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/ie11-detection": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
-      "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
-      "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/sha256-browser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.0.0.tgz",
-      "integrity": "sha512-uSufui4ZktC5lYX6bDxgBgNboxGyw9V9V+rlcNsNTxh4YPhOdCslwJMGntiWOBRGAgXhhvWi7FqnTS2SaT3cpg==",
-      "requires": {
-        "@aws-crypto/ie11-detection": "^1.0.0",
-        "@aws-crypto/sha256-js": "^1.0.0",
-        "@aws-crypto/supports-web-crypto": "^1.0.0",
-        "@aws-sdk/types": "^1.0.0-rc.1",
-        "@aws-sdk/util-locate-window": "^1.0.0-rc.1",
-        "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "@aws-sdk/util-utf8-browser": {
-          "version": "1.0.0-rc.8",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-rc.8.tgz",
-          "integrity": "sha512-clncPMJ23rxCIkZ9LoUC8SowwZGxWyN2TwRb0XvW/Cv9EavkRgRCOrCpneGyC326lqtMKx36onnpaSRHxErUYw==",
-          "requires": {
-            "tslib": "^1.8.0"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/sha256-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0.tgz",
-      "integrity": "sha512-89kqtFs/tdHBFHEBXZ4UXlCISswvEor3BVVOriR68Tbk1Qe1zBOZtfbSOt3CDT69z88x5uM558YW9k8I1xei5A==",
-      "requires": {
-        "@aws-sdk/types": "^1.0.0-rc.1",
-        "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "@aws-sdk/util-utf8-browser": {
-          "version": "1.0.0-rc.8",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-1.0.0-rc.8.tgz",
-          "integrity": "sha512-clncPMJ23rxCIkZ9LoUC8SowwZGxWyN2TwRb0XvW/Cv9EavkRgRCOrCpneGyC326lqtMKx36onnpaSRHxErUYw==",
-          "requires": {
-            "tslib": "^1.8.0"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/supports-web-crypto": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
-      "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
-      "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-vNLvkOp4CRovVvm7OGOTiQYnpRK3EgrP0fVOjVHEqo3Qep3u2JJi/Ifo931K/Yd7cWlbtLbttqguGBCPcWWlgw==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/chunked-blob-reader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.0.0.tgz",
-      "integrity": "sha512-FVAYcWnLHoMT6WVuzz3BxkZ9mDHTUtG1bXAl0EnE7xdK1wcwmX5OtZNZLjTHgFLxKGl8zuNjBVozcccYnHBcEw==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.0.0.tgz",
-      "integrity": "sha512-AveoLJ+OXctID0GZJ+pM9aLO43yp8GQvt4TgFVE3tNAq5hOkQ5uSe2Uzj6KwBUUrSnaVDYPaS7FoeRbXeHwpfw==",
-      "requires": {
-        "@aws-sdk/util-base64-browser": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/client-s3": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.0.0.tgz",
-      "integrity": "sha512-IqwIvvAgEJl2O5nF+qCmsTLGhFornLdbBd31kgHjgjULM4Ocx1nL7nxi3vKsRDVqTvJESSh4puJVUkjNYpWlDg==",
-      "requires": {
-        "@aws-crypto/sha256-browser": "^1.0.0",
-        "@aws-crypto/sha256-js": "^1.0.0",
-        "@aws-sdk/config-resolver": "3.0.0",
-        "@aws-sdk/credential-provider-node": "3.0.0",
-        "@aws-sdk/eventstream-serde-browser": "3.0.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.0.0",
-        "@aws-sdk/eventstream-serde-node": "3.0.0",
-        "@aws-sdk/fetch-http-handler": "3.0.0",
-        "@aws-sdk/hash-blob-browser": "3.0.0",
-        "@aws-sdk/hash-node": "3.0.0",
-        "@aws-sdk/hash-stream-node": "3.0.0",
-        "@aws-sdk/invalid-dependency": "3.0.0",
-        "@aws-sdk/md5-js": "3.0.0",
-        "@aws-sdk/middleware-apply-body-checksum": "3.0.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.0.0",
-        "@aws-sdk/middleware-content-length": "3.0.0",
-        "@aws-sdk/middleware-expect-continue": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.0.0",
-        "@aws-sdk/middleware-location-constraint": "3.0.0",
-        "@aws-sdk/middleware-logger": "3.0.0",
-        "@aws-sdk/middleware-retry": "3.0.0",
-        "@aws-sdk/middleware-sdk-s3": "3.0.0",
-        "@aws-sdk/middleware-serde": "3.0.0",
-        "@aws-sdk/middleware-signing": "3.0.0",
-        "@aws-sdk/middleware-ssec": "3.0.0",
-        "@aws-sdk/middleware-stack": "3.0.0",
-        "@aws-sdk/middleware-user-agent": "3.0.0",
-        "@aws-sdk/node-config-provider": "3.0.0",
-        "@aws-sdk/node-http-handler": "3.0.0",
-        "@aws-sdk/protocol-http": "3.0.0",
-        "@aws-sdk/smithy-client": "3.0.0",
-        "@aws-sdk/url-parser-browser": "3.0.0",
-        "@aws-sdk/url-parser-node": "3.0.0",
-        "@aws-sdk/util-base64-browser": "3.0.0",
-        "@aws-sdk/util-base64-node": "3.0.0",
-        "@aws-sdk/util-body-length-browser": "3.0.0",
-        "@aws-sdk/util-body-length-node": "3.0.0",
-        "@aws-sdk/util-user-agent-browser": "3.0.0",
-        "@aws-sdk/util-user-agent-node": "3.0.0",
-        "@aws-sdk/util-utf8-browser": "3.0.0",
-        "@aws-sdk/util-utf8-node": "3.0.0",
-        "@aws-sdk/util-waiter": "3.0.0",
-        "@aws-sdk/xml-builder": "3.0.0",
-        "fast-xml-parser": "^3.16.0",
-        "tslib": "^2.0.0"
-      }
-    },
-    "@aws-sdk/config-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.0.0.tgz",
-      "integrity": "sha512-UGLud2uYwN1XOXX0xzSLoCcTrOkBIKIo1Ls0mN0dEryAQlFr2plR52Ze8OdjojXt49ZIrmb4WmPNFfszjwmkdA==",
-      "requires": {
-        "@aws-sdk/signature-v4": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/credential-provider-env": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.0.0.tgz",
-      "integrity": "sha512-LzV08Cvwipfrf3POdKENFFN+0Gc1d/tlS+mJoym81yULUb8HE9RDGic5uvzRuv1ylWm2X/uAEtQjPlbzl3Tatg==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/credential-provider-imds": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.0.0.tgz",
-      "integrity": "sha512-6lKQ1Z+c0VZgd1QILiRKY/28/vwG1IeSAX1NIDR8wFacbo8y+2b9dGg40fjw2MwSBPOyMHE3hkNJJ1BZrHZpSg==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/credential-provider-ini": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.0.0.tgz",
-      "integrity": "sha512-/M4MxULEPQtUqTrYB825ZVnwWdrrgVB9WmbPl9Zo8urmEDRN5+iPhYpCClpbbb02Y5KXdfa3sl5VZYny190E7A==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.0.0",
-        "@aws-sdk/shared-ini-file-loader": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/credential-provider-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.0.0.tgz",
-      "integrity": "sha512-NUvIWY5+K5nb5KxZFFvUkKtL33QwaQ78S43nhR5u/kMwCuB0Bbzzcpqtz+zcsMkZNNUtNOwMeZnP/4RiXuohbA==",
-      "requires": {
-        "@aws-sdk/credential-provider-env": "3.0.0",
-        "@aws-sdk/credential-provider-imds": "3.0.0",
-        "@aws-sdk/credential-provider-ini": "3.0.0",
-        "@aws-sdk/credential-provider-process": "3.0.0",
-        "@aws-sdk/property-provider": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/credential-provider-process": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.0.0.tgz",
-      "integrity": "sha512-s5PFEufIRILR8rIvDIDqgk2nwCsqvN64j/Opj2gv2xgS6nqSWwr6oDHN67qru4haah7NQ19l7tP5oxcdVL820w==",
-      "requires": {
-        "@aws-sdk/credential-provider-ini": "3.0.0",
-        "@aws-sdk/property-provider": "3.0.0",
-        "@aws-sdk/shared-ini-file-loader": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/eventstream-marshaller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.0.0.tgz",
-      "integrity": "sha512-mxAntbrX5KJGKD8kpTnAZs6WgkPrxU3TFNUj3wm018K0XEubrmim71pWZZkif1KXdF/XCvW0m0Nq2VlLDFYCyA==",
-      "requires": {
-        "@aws-crypto/crc32": "^1.0.0",
-        "@aws-sdk/util-hex-encoding": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.0.0.tgz",
-      "integrity": "sha512-C79h0bbPkIwJHVzSLJOIW2shX5+FMpYFzWmHs5B29vp3LjwxDhl+Ju1NmSeC3mpsVVnue1hLr/n+dHO/aQtSWw==",
-      "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.0.0",
-        "@aws-sdk/eventstream-serde-universal": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.0.tgz",
-      "integrity": "sha512-BNLS+OpY//1bwgOMYhvu2uyXayJOT24uiSfK1hEpjyYfyvMSgT9CCIkNv6ZElzY1NpwoC7mbyHIq2aSHW8kq8w==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/eventstream-serde-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.0.0.tgz",
-      "integrity": "sha512-jt9UnXRFaxNhLnX17+A8G1wg5xlLMWvRSZDidVY+mYiSpk5UG7rGVgzViGU7ORCmDdZOyDSjUay+2hII22rr/w==",
-      "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.0.0",
-        "@aws-sdk/eventstream-serde-universal": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.0.0.tgz",
-      "integrity": "sha512-xW6GAsDtwFT5qJosm9zv8H/Ek3O7yRkkRlblN5adhK7VJ2ZOZRSa+1834AVHow1FatIqkO+PP5dBnOUgVCrocw==",
-      "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/fetch-http-handler": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.0.0.tgz",
-      "integrity": "sha512-2UX5e2YP+tv8CujNZs4+kU9aSVhAZn8HsOPM9uWFSHoEJkLsaetCaxYOzt9swag3OYnTffpVrqh4b9N2yPnUCQ==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.0.0",
-        "@aws-sdk/querystring-builder": "3.0.0",
-        "@aws-sdk/util-base64-browser": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/hash-blob-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.0.0.tgz",
-      "integrity": "sha512-8Jl6etn2lGND9kP3bGgwpSOjyTdIcE4ynY4rc8ogvjFKbxnmUNtDmylUSNfFv6+dvi0861I+9H7M7zxoI1I2dw==",
-      "requires": {
-        "@aws-sdk/chunked-blob-reader": "3.0.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/hash-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.0.0.tgz",
-      "integrity": "sha512-AMKT/Tg5AmJPBA2yyERf0pA8T7+Pr9Ss1ZBYN8QGc3mLtH168uHdi85pu/5fv8+ubEO6NVyPD6MAibgWWIQ0rw==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/hash-stream-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.0.0.tgz",
-      "integrity": "sha512-0WzkHMPvlbk2Wz710OKZotjD1rwCHvSFtftpCrt8cZZpM2i7qVBO8D2Z2Vj+DSvFhFsU1o/Ro/dPRmGXkHrGyg==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/invalid-dependency": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.0.0.tgz",
-      "integrity": "sha512-lAP5OpkxPB0a3sscfqhFOeLaCVIUvi0zSuLdoCXfqGjl2SYgq27U9IsFM2qHjAGrg1VrqhRWxi+7XzKNnI0E+Q==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/is-array-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-      "integrity": "sha512-XEDXuZKHFDlBfeFU02b1bjN5KY2+7j+owXebe9A5qGKT2istaoY0TASidibJVd2qdj38zf+e8xKXvW/Akiha2Q==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/md5-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.0.0.tgz",
-      "integrity": "sha512-9OAUcOkhfjHQcJjPEfz5vG3Fbc7VyHKbt0gl5suIfURFmKUKQ+OduCwfafCf0m6j7IGN2+hm652wNGo/k2Bhzw==",
-      "requires": {
-        "@aws-sdk/util-utf8-browser": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-apply-body-checksum": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.0.0.tgz",
-      "integrity": "sha512-XvyYOj8C4Hc0n8/H2LfLisn9o3NpZtb6iOVmj0pIbPAserkbzHWozqIVrjgiMueB8HKE+lIm1xJCzb7DQqQwqQ==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.0.0",
-        "@aws-sdk/protocol-http": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.0.0.tgz",
-      "integrity": "sha512-JspvMQxgBivwJTMDfuuZwGOvucVfS25D7LN7LNuAbO6AW0gWXyVULEkOppKJcR/XkqMSyqLIaXnA6YG/+c3fMQ==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.0.0",
-        "@aws-sdk/util-arn-parser": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-content-length": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.0.0.tgz",
-      "integrity": "sha512-AVpoUMF3iBAnZ/T6F55PLjI1HfNSYlcG2dvoDkP823UrQf4J/yNgOZ5CVoz3yaz/8Lp6ZkUF+I4QnJIPNaFllg==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-expect-continue": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.0.0.tgz",
-      "integrity": "sha512-k+n3VpE7l8PH1bV6ROKIWeZMPvlEx/yvpOtE4sH6smnqKlAJ+yRogD8XxBOzvf2fRhO33M2NJR3xl1UHfLMPrQ==",
-      "requires": {
-        "@aws-sdk/middleware-header-default": "3.0.0",
-        "@aws-sdk/protocol-http": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-header-default": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.0.0.tgz",
-      "integrity": "sha512-aTj8+7gkzOv+RgKxvtWmd6F8V/3fsGsGMlXjcpniAlfXbkjHVhSVmsLStIs3llXHLUuOkaigLJe0hTskvPnY1w==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-host-header": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.0.0.tgz",
-      "integrity": "sha512-/SjdWI/45aWvOPu8fV+7POpSK/ujHucq15BJfWfRrjBpT7i3n6qlpolGnNLJnexMiZYrhK+tWvSDUTK1KRRQVw==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-location-constraint": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.0.0.tgz",
-      "integrity": "sha512-P5htyuVx0lT4UOMKeMgAp+Bn4dKkOJsVjvLv/buK5dYf32mMyzI/gpmete43PcGSG1xve7wxgFNebWNpC2DpEg==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-logger": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.0.0.tgz",
-      "integrity": "sha512-RKXrwBuipom98prNE9bwv8k9tntvXc/YxJ1wgD8F4LgXCTO6X3xh7SYTQyC/Ih/kK0qUpW00uYPvLbu9tpmkeA==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-retry": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.0.0.tgz",
-      "integrity": "sha512-ZwqMYQcEi3kYjQiDgiBdmkyKuvami8hE6TbQvFT2/Kyelrf78rXpPD03tOyEJnsmo1ohHf0aYCavepg46kwuPw==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.0.0",
-        "@aws-sdk/service-error-classification": "3.0.0",
-        "react-native-get-random-values": "^1.4.0",
-        "tslib": "^1.8.0",
-        "uuid": "^3.0.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.0.0.tgz",
-      "integrity": "sha512-9EcThJaQ8h1lYaDR+Q7kMtYJRCxak0DYdeh2nEmCy1ic6Nak7ZNkaTkvGJdFJD3M1LL9pzAKlxEpgIrpPSfVTw==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.0.0",
-        "@aws-sdk/util-arn-parser": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-serde": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.0.0.tgz",
-      "integrity": "sha512-QY11ZXOkOc59+xayTCXdZxqzrjtI3sT9IWBy6/LyylAN+y7xtuCwiCvXf+YkiYpBORI5ZNC4Mjwuy0Nf0rkoIg==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-signing": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.0.0.tgz",
-      "integrity": "sha512-8lj42dCbGQkgx7EMienpXLTbko0U7TAsmpRIYT6w0wEjCq0O77cuQYJYacdu163adlZnw5gAzlSlR0OXNb/SGg==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.0.0",
-        "@aws-sdk/signature-v4": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-ssec": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.0.0.tgz",
-      "integrity": "sha512-ILnzIkllg2uCDwg0Vnj+mTnTLjCqxEl/PReUyy7KdPPKW92q7vOcn/miB2Fth6NIST7zne69REhsdNcyM2X/tA==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-stack": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.0.0.tgz",
-      "integrity": "sha512-ULTe6G1bIk8OuK20lq+v5AOPjszRnfXt/pY4C3KxKLYOq/zn6CSOAKWbMM5QZEGV6y9T1ISWgFcdsnBoMBjRlw==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-user-agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.0.0.tgz",
-      "integrity": "sha512-x7YE5JtILf6Q8paizfnwHvypXY5nXGT1akPUQk2L65mL+Hnc6DbTLjkRsPZ8yRHcs86fWaNescflXQ4itttK9Q==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/node-config-provider": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.0.0.tgz",
-      "integrity": "sha512-UD3W0djDC6z6mNbu0JI54pujzowWU+9y9yvLJDfNeUwBd5rnOQfLqaE9z6UGBtdKZbieH18wWrCK10JF7cr6uQ==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.0.0",
-        "@aws-sdk/shared-ini-file-loader": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/node-http-handler": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.0.0.tgz",
-      "integrity": "sha512-KlrW45M/MQEu+ZsDEqrrHI1lLnURLdHtC8yYoLF5XuBGRfpm35KaNZBqht8x+sVfZUJq9qfHhhoe+rLrqNXe5g==",
-      "requires": {
-        "@aws-sdk/abort-controller": "3.0.0",
-        "@aws-sdk/protocol-http": "3.0.0",
-        "@aws-sdk/querystring-builder": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/property-provider": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.0.0.tgz",
-      "integrity": "sha512-XgTXGTjHkzpU/YlscY/DCstfrdv3xd+qE4kbKmIj1dEVn7Y4mbIju6h0wSATajW1kOdaXiq3gS/RbqIBOpgdiA==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/protocol-http": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.0.0.tgz",
-      "integrity": "sha512-fqSdd0Euv5ETc8C2qp0sCoC0YFNRvyBWbizl3zFWUr/pAW7KIMiSPByO3fdelJMYvQsQ093+AI3tGSl4qFvVZw==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/querystring-builder": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.0.0.tgz",
-      "integrity": "sha512-qPm+1vRCRQOqxBvBx/moecyNKLxoQnNVawSG6jrVU5RRNebFeJd/Xh1+Me1c+feWx9YeR0+sAq4ELewDCZOy0Q==",
-      "requires": {
-        "@aws-sdk/util-uri-escape": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/querystring-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.0.0.tgz",
-      "integrity": "sha512-uZFw1V57rebnGobE5fyBaGn72bulDQHpZgEBX/l9PBs7z2wBogaz9hsqxn0h5+hWbnyNE2odoFGtk3ZdHm9VnQ==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/service-error-classification": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.0.0.tgz",
-      "integrity": "sha512-Pw73nb1E195S8GaIHH+69ITYB7KVo5I6UrrlwZNfSqtB30A5Tj5K/p5HKjJZln9Th3+ESfkf4ajg+j7KkJ/0dw=="
-    },
-    "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.0.0.tgz",
-      "integrity": "sha512-zcuyi3O1vaeKDIHVljGY3v6xAwZrz54EnjQWIc37OyXXY611NmqPMrW5IoG3VCXLwZSTxGuqjWX5IhHRt6xOtw==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/signature-v4": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.0.0.tgz",
-      "integrity": "sha512-ocstLMrDP2BO0znDHaboAYQB6PosEUWbr07c3IUmV5Vij8Xc/cODQusVSmKdLvEE4qwMaK/yZ4n9sSe8uuZqqg==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.0.0",
-        "@aws-sdk/util-hex-encoding": "3.0.0",
-        "@aws-sdk/util-uri-escape": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/smithy-client": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.0.0.tgz",
-      "integrity": "sha512-qT7v27KHNBh6nUH7rsk4EcRKJEahdD1eWUrR25fJ+vZQIDEe+reNKDIPalR60plrjvfrCiFkxL21pjq3KA1JVQ==",
-      "requires": {
-        "@aws-sdk/middleware-stack": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/types": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-1.0.0-rc.10.tgz",
-      "integrity": "sha512-9gwhYnkTNuYZ+etCtM4T8gjpZ0SWSXbzQxY34UjSS+dt3C/UnbX0J22tMahp/9Z1yCa9pihtXrkD+nO2xn7nVQ=="
-    },
-    "@aws-sdk/url-parser-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-browser/-/url-parser-browser-3.0.0.tgz",
-      "integrity": "sha512-Y2GLy/G+AT5FnAU96BOT2GGqRCX9ZzokZucfPwFiPc6Y7GGqJqt4wSmPkg5hj6EKiPYBIEjZzqoS+0Q2RkqmpQ==",
-      "requires": {
-        "@aws-sdk/querystring-parser": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/url-parser-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser-node/-/url-parser-node-3.0.0.tgz",
-      "integrity": "sha512-3alAzkuY+CmQt89Q608dQ+VDCSzEc/MlgU+4P3O3Dk0xQqUGxQz3sErhyoY0d77jTY6bVU8H7SFvcwFCdO0NCg==",
-      "requires": {
-        "@aws-sdk/querystring-parser": "3.0.0",
-        "tslib": "^1.8.0",
-        "url": "^0.11.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/util-arn-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.0.0.tgz",
-      "integrity": "sha512-srQjwEnavosPNRvTXhp+tv9tQ7+4tJTO5r8B5nWU1ApVQQrj1Y6NeVMobAI971Di2JslAXXlMWdZf4VuIy3NMg==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/util-base64-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.0.0.tgz",
-      "integrity": "sha512-1jtiaXdo3skMFGYNPAo5r8ttimakvfelu1LyoMH0S4Pddxk3+YKr3h8jzbLJzfm9avp1ollJakLZmGkkiNJVJA==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/util-base64-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.0.0.tgz",
-      "integrity": "sha512-PgV179JbcAm+rTe02/F4YbhD9eTdZrx+PCyiDb6vX18MmY0pydsdXSmQZ9KbWbaj6Ony5bcLLtPEdalf6vu3Zw==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/util-body-length-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
-      "integrity": "sha512-NV3vBGKa5k3bEzXlrSI444F/JZRfWtGRZl/D+Ve5KdseRv7KJbV3L8M62zswAmyxMYku1RyRENEZ1VnjNff5yg==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/util-body-length-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
-      "integrity": "sha512-zt9Jivz3rkeWOUkZFClXzHcX6tcPbTaYzKSZOMwi0H0IlhSM/yllDjLuj12VlBG9f9BarxGA1Mj1RAK2CvzsSA==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-Z/tU7/O0G2lYImMvAchCrPk2L8OmIs2pHi58kXEtHk/hxZXT1sJIZLErd3OFYaDFLaqOeEkebWB+jseBXJLv3Q==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/util-hex-encoding": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
-      "integrity": "sha512-bYWnM1I9vv1IhrCrcp6cEjqkJUAeheFFFUSM/VANMN8AgXzdjMeR8JNejnSB8Lw3Oi9LZ+uHV+cXHanW55qymw==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/util-locate-window": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-1.0.0-rc.8.tgz",
-      "integrity": "sha512-TvqeA4fgmZ0A0x3K+qVj/OSWEFHGZjzpVuyXlm1EYOf7NQ9VWRlokEn1MYKuL+t7al9ZeQyi16D8Dn7DW1eidw==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/util-uri-escape": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
-      "integrity": "sha512-xl4ALVX/YbmFxg6NvmLv/TsPMxcizrmXvl0x79JhSRYU2cyvhgh2EuMrUzcitixgsYtdGqihWe3tj9Z8zXDRSg==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/util-user-agent-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.0.0.tgz",
-      "integrity": "sha512-ivveMLf7Op2b022buy3Uwy/ctEQyAGWjK/TgnYX4Hv8uvJREJURIXSeAvohT/dlhy54Mhd40nlr3eJY35BTpSw==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/util-user-agent-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.0.0.tgz",
-      "integrity": "sha512-tUjVOgidkbuUK+XSloYTX7P/dbpGdvYHKOmKAGp72fRikfLxGazJcNS7wJ5RalVErIoH5/C6e6EJI8azKubpHg==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/util-utf8-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.0.0.tgz",
-      "integrity": "sha512-7vTn2KFOjUter7wwCjyQ+iJWvREOI8WAYyXSbD222dkY3VB/DAYFtMDErc4Sh4Onu2WPzdKJ6fnYwCpAxibHOQ==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/util-utf8-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.0.0.tgz",
-      "integrity": "sha512-0pCFuWqABvv14dVTMQBWQh95CR2gCNQxu9aOOYr8GR37wqdgNvsSCzrmapydG4Q0FBNoTkqtx/7Nqdedb3+EXg==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/util-waiter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.0.0.tgz",
-      "integrity": "sha512-Z2AYDLNVAsTdq5ImbrbrfM+/QopZIPXn36WNTNV4cAfUs8p5YmsdZyjlaSH1l4THru4e7ngqAm+Y5wJ5iqH0hg==",
-      "requires": {
-        "@aws-sdk/abort-controller": "3.0.0",
-        "@aws-sdk/types": "3.0.0",
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.0.0.tgz",
-          "integrity": "sha512-D2sSHRZRw0ixox5+Dx7xPvTfMLZQzxJ/nWDP26FAl+c/i/402d0Y9acfDtUxfxPxCbVogZ3XgZXhjDY/RmMAjQ=="
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/xml-builder": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.0.0.tgz",
-      "integrity": "sha512-bExhgT1KH4JSBddcMNfQpVptfIBI707g55BC53kfs1csvfRgpgtzJYx96fhcvAXCDIkK98KBrwnpTCCoF6HMqA==",
-      "requires": {
-        "tslib": "^1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -3839,6 +2674,87 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "aws-sdk": {
+      "version": "2.815.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.815.0.tgz",
+      "integrity": "sha512-BXL3Og97rOY9jE7OeYQdKftMAZ3SneFg/rBslyog+W0dTDKq3NBuM3fBWhc3POf26kHcFjsnLIWScM8bWhD4AA==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "ieee754": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "xml2js": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+          "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+          "requires": {
+            "sax": ">=0.6.0",
+            "xmlbuilder": "~9.0.1"
+          }
+        },
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -6406,11 +5322,6 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
-    "fast-base64-decode": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
-      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q=="
-    },
     "fast-csv": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
@@ -6468,11 +5379,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
-    },
-    "fast-xml-parser": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.5.tgz",
-      "integrity": "sha512-lEvThd1Xq+CCylf1n+05bUZCDZjTufaaaqpxM3JZ+4iDqtlG+d/oKgtMmg9GEMOuzBgUoalIzFOaClht9YiGJQ=="
     },
     "fastq": {
       "version": "1.9.0",
@@ -9295,6 +8201,11 @@
         }
       }
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "joi": {
       "version": "17.3.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.3.0.tgz",
@@ -10957,14 +9868,6 @@
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
-      }
-    },
-    "react-native-get-random-values": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.5.0.tgz",
-      "integrity": "sha512-LK+Wb8dEimJkd/dub7qziDmr9Tw4chhpzVeQ6JDo4czgfG4VXbptRyOMdu8503RiMF6y9pTH6ZUTkrrpprqT7w==",
-      "requires": {
-        "fast-base64-decode": "^1.0.0"
       }
     },
     "read-pkg": {
@@ -13083,22 +11986,6 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
-    },
-    "url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-        }
-      }
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^1.0.0-rc.10",
     "@nestjs/bull": "^0.3.1",
     "@nestjs/common": "^7.6.1",
     "@nestjs/config": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,9 @@
       "@app/storage/(.*)": "<rootDir>/libs/storage/src/$1",
       "@app/storage": "<rootDir>/libs/storage/src",
       "@app/snapshot/(.*)": "<rootDir>/libs/snapshot/src/$1",
-      "@app/snapshot": "<rootDir>/libs/snapshot/src"
+      "@app/snapshot": "<rootDir>/libs/snapshot/src",
+      "@app/datetime/(.*)": "<rootDir>/libs/datetime/src/$1",
+      "@app/datetime": "<rootDir>/libs/datetime/src"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -125,7 +125,9 @@
       "@app/ingest/(.*)": "<rootDir>/libs/ingest/src/$1",
       "@app/ingest": "<rootDir>/libs/ingest/src",
       "@app/solutions-scanner/(.*)": "<rootDir>/libs/solutions-scanner/src/$1",
-      "@app/solutions-scanner": "<rootDir>/libs/solutions-scanner/src"
+      "@app/solutions-scanner": "<rootDir>/libs/solutions-scanner/src",
+      "@app/storage/(.*)": "<rootDir>/libs/storage/src/$1",
+      "@app/storage": "<rootDir>/libs/storage/src"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -128,7 +128,9 @@
       "@app/solutions-scanner/(.*)": "<rootDir>/libs/solutions-scanner/src/$1",
       "@app/solutions-scanner": "<rootDir>/libs/solutions-scanner/src",
       "@app/storage/(.*)": "<rootDir>/libs/storage/src/$1",
-      "@app/storage": "<rootDir>/libs/storage/src"
+      "@app/storage": "<rootDir>/libs/storage/src",
+      "@app/snapshot/(.*)": "<rootDir>/libs/snapshot/src/$1",
+      "@app/snapshot": "<rootDir>/libs/snapshot/src"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.0.0",
     "@nestjs/bull": "^0.3.1",
     "@nestjs/common": "^7.6.1",
     "@nestjs/config": "^0.6.1",
@@ -43,6 +42,7 @@
     "@nestjs/platform-express": "^7.6.1",
     "@nestjs/schedule": "^0.4.1",
     "@nestjs/typeorm": "^7.1.5",
+    "aws-sdk": "^2.815.0",
     "bull": "^3.20.0",
     "class-transformer": "^0.3.1",
     "class-validator": "^0.12.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^1.0.0-rc.10",
+    "@aws-sdk/client-s3": "^3.0.0",
     "@nestjs/bull": "^0.3.1",
     "@nestjs/common": "^7.6.1",
     "@nestjs/config": "^0.6.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,10 @@
   "compilerOptions": {
     "module": "commonjs",
     "lib": [
-      "ES2020.String", 
-      "es5", 
-      "es6", 
-      "dom", 
+      "ES2020.String",
+      "es5",
+      "es6",
+      "dom",
       "dom.iterable"
     ],
     "declaration": true,
@@ -60,6 +60,12 @@
       ],
       "@app/solutions-scanner/*": [
         "libs/solutions-scanner/src/*"
+      ],
+      "@app/storage": [
+        "libs/storage/src"
+      ],
+      "@app/storage/*": [
+        "libs/storage/src/*"
       ]
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -66,6 +66,12 @@
       ],
       "@app/storage/*": [
         "libs/storage/src/*"
+      ],
+      "@app/snapshot": [
+        "libs/snapshot/src"
+      ],
+      "@app/snapshot/*": [
+        "libs/snapshot/src/*"
       ]
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -72,6 +72,12 @@
       ],
       "@app/snapshot/*": [
         "libs/snapshot/src/*"
+      ],
+      "@app/datetime": [
+        "libs/datetime/src"
+      ],
+      "@app/datetime/*": [
+        "libs/datetime/src/*"
       ]
     }
   }


### PR DESCRIPTION
Why: This feature adds a JSON snapshot of the database to S3. This allows for bulk downloading from S3 (as opposed to through the API). It also archives any existing files and copies them to an `/archive` directory in S3. There is also a local version set up, that uses `minio` in place of S3.

How: This feature adds a few things to the codebase. 1) The `StorageService` which interfaces with S3, 2) The `SnapshotService` which is responsible for the logic of querying the database, and archival and storage into S3, 3) and the `DatetimeService` which mostly exists for making testing easier. 

The main public API to be concerned with is probably the `SnapshotService.weeklySnapshot()`. This is used by the `TaskService` which manages the cron logic. This is currently being called daily (while testing the feature) but has an independent schedule set by the `SNAPSHOT_SCHEDULE` environment variable. 

Closes https://github.com/18F/site-scanning/issues/824

Tags: s3, archival, storage, snapshot