### PR TITLE
Add new target url list.

### DIFF
--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -19,6 +19,13 @@ async function ingest(cmdObj) {
   } else {
     await controller.writeUrls();
   }
+
+  const used = process.memoryUsage();
+  for (const key in used) {
+    console.log(
+      `${key} ${Math.round((used[key] / 1024 / 1024) * 100) / 100} MB`,
+    );
+  }
 }
 
 async function main() {

--- a/apps/scan-engine/src/scan-engine.consumer.ts
+++ b/apps/scan-engine/src/scan-engine.consumer.ts
@@ -2,7 +2,15 @@ import { CoreScannerService } from '@app/core-scanner';
 import { CoreResultService } from '@app/database/core-results/core-result.service';
 import { LoggerService } from '@app/logger';
 import { CORE_SCAN_JOB_NAME, SCANNER_QUEUE_NAME } from '@app/message-queue';
-import { Process, Processor } from '@nestjs/bull';
+import {
+  OnQueueActive,
+  OnQueueCompleted,
+  OnQueueDrained,
+  OnQueueError,
+  OnQueueStalled,
+  Process,
+  Processor,
+} from '@nestjs/bull';
 import { Job } from 'bull';
 import { CoreInputDto } from '@app/core-scanner/core.input.dto';
 import { SolutionsResultService } from '@app/database/solutions-results/solutions-result.service';
@@ -14,6 +22,9 @@ import { SolutionsScannerService } from 'libs/solutions-scanner/src';
  * @remarks the ScanEngineConsumer pulls work off of the Scanner queue and processes it.
  * The methods in ScanConsumer should use the `Process` decorator. This allows us to route
  * named jobs to the correct processor, e.g.
+ *
+ * ScanEngineConsumer also provides several useful event listeners for understanding the
+ * state of the queue at various times.
  *
  * ```ts
  * @Process('SomeNamedJob')
@@ -56,14 +67,49 @@ export class ScanEngineConsumer {
       const solutionsResult = await this.solutionsScanner.scan(job.data);
       await this.solutionsResultService.create(solutionsResult);
       this.logger.debug(`wrote solutions result for ${job.data.url}`);
-
-      await job.moveToCompleted();
     } catch (e) {
       const err = e as Error;
       this.logger.error(err.message, err.stack);
-      await job.moveToFailed({
-        message: err.message,
-      });
     }
+  }
+
+  @OnQueueActive()
+  onActive(job: Job<CoreInputDto>) {
+    this.logger.debug(
+      `Processing job ${job.id} of type ${job.name} with data ${JSON.stringify(
+        job.data,
+      )}...`,
+    );
+  }
+
+  @OnQueueStalled()
+  onStalled(job: Job<CoreInputDto>) {
+    this.logger.debug(
+      `Queue stalled while processing job ${job.id} of type ${job.name} with data ${job.data}...`,
+    );
+  }
+
+  @OnQueueDrained()
+  onDrained() {
+    this.logger.debug(
+      `Queue successfully drained at ${this.logger.getTimestamp()}`,
+    );
+  }
+
+  @OnQueueError()
+  onError(error: Error) {
+    this.logger.error(
+      `Queue Error "${error.name}" detected: ${error.message}`,
+      error.stack,
+    );
+  }
+
+  @OnQueueCompleted()
+  onCompleted(job: Job<CoreInputDto>, result: any) {
+    this.logger.debug(
+      `Processed job ${job.id} of type ${job.name} with data ${JSON.stringify(
+        job.data,
+      )}`,
+    );
   }
 }

--- a/deploy-cloudgov.sh
+++ b/deploy-cloudgov.sh
@@ -93,6 +93,9 @@ if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
   # next, compile the typescript for all of the apps
   npm run build:all
 
+  # next, build the cli
+  npm run build cli
+
   # deploy to cloud.gov
   cf push
 fi

--- a/entities/website.entity.ts
+++ b/entities/website.entity.ts
@@ -38,27 +38,27 @@ export class Website {
 
   @Column()
   @Expose({ name: 'target_url_branch' })
-  type: string;
+  branch: string;
 
   @Column()
   @Expose({ name: 'target_url_agency_owner' })
   agency: string;
 
+  @Column({
+    nullable: true,
+  })
+  @Expose({ name: 'target_url_agency_code' })
+  agencyCode?: number;
+
   @Column()
   @Expose({ name: 'target_url_bureau_owner' })
-  organization: string;
+  bureau: string;
 
-  @Column()
-  @Exclude({ toPlainOnly: true })
-  city: string;
-
-  @Column()
-  @Exclude({ toPlainOnly: true })
-  state: string;
-
-  @Column()
-  @Exclude({ toPlainOnly: true })
-  securityContactEmail: string;
+  @Column({
+    nullable: true,
+  })
+  @Expose({ name: 'target_url_bureau_code' })
+  bureauCode?: number;
 
   serialized() {
     const serializedWebsite = classToPlain(this);

--- a/libs/core-scanner/src/core-scanner.service.ts
+++ b/libs/core-scanner/src/core-scanner.service.ts
@@ -25,7 +25,9 @@ export class CoreScannerService
     @Inject(BROWSER_TOKEN) private browser: Browser,
     private logger: LoggerService,
     private httpService: HttpService,
-  ) {}
+  ) {
+    this.logger.setContext(CoreScannerService.name);
+  }
 
   async scan(input: CoreInputDto) {
     const url = this.getHttpsUrl(input.url);
@@ -173,7 +175,7 @@ export class CoreScannerService
 
     const resp = await this.httpService
       .get(randomUrl.toString(), {
-        validateStatus: _ => {
+        validateStatus: (_) => {
           return true;
         },
         httpsAgent: agent,

--- a/libs/database/src/core-results/core-result.service.ts
+++ b/libs/database/src/core-results/core-result.service.ts
@@ -9,7 +9,9 @@ export class CoreResultService {
   constructor(
     @InjectRepository(CoreResult) private coreResult: Repository<CoreResult>,
     private logger: LoggerService,
-  ) {}
+  ) {
+    this.logger.setContext(CoreResultService.name);
+  }
 
   async findAll(): Promise<CoreResult[]> {
     const results = await this.coreResult.find();

--- a/libs/database/src/websites/dto/create-website.dto.ts
+++ b/libs/database/src/websites/dto/create-website.dto.ts
@@ -2,11 +2,10 @@
  * CreateWebsiteDto is the fields required to create a website.
  */
 export class CreateWebsiteDto {
-  url: string;
-  type: string;
+  website: string;
+  branch: string;
   agency: string;
-  organization: string;
-  city: string;
-  state: string;
-  securityContactEmail: string;
+  agencyCode?: number;
+  bureau: string;
+  bureauCode?: number;
 }

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -54,8 +54,8 @@ export class WebsiteService {
     }
 
     if (dto.target_url_bureau_owner) {
-      query.andWhere('organization = :organization', {
-        organization: dto.target_url_bureau_owner,
+      query.andWhere('bureau = :bureau', {
+        bureau: dto.target_url_bureau_owner,
       });
     }
 

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -17,9 +17,12 @@ export class WebsiteService {
   ) {}
 
   async findAll(): Promise<Website[]> {
-    const websites = await this.website.find({
-      relations: ['coreResult', 'solutionsResult'],
-    });
+    const websites = this.website
+      .createQueryBuilder('website')
+      .leftJoinAndSelect('website.coreResult', 'coreResult')
+      .leftJoinAndSelect('website.solutionsResult', 'solutionsResult')
+      .getMany();
+
     return websites;
   }
 
@@ -103,13 +106,12 @@ export class WebsiteService {
 
   async create(createWebsiteDto: CreateWebsiteDto) {
     const website = new Website();
-    website.url = createWebsiteDto.url;
+    website.url = createWebsiteDto.website;
     website.agency = createWebsiteDto.agency;
-    website.organization = createWebsiteDto.organization;
-    website.type = createWebsiteDto.type;
-    website.city = createWebsiteDto.city;
-    website.state = createWebsiteDto.state;
-    website.securityContactEmail = createWebsiteDto.securityContactEmail;
+    website.bureau = createWebsiteDto.bureau;
+    website.branch = createWebsiteDto.branch;
+    website.agencyCode = createWebsiteDto.agencyCode;
+    website.bureauCode = createWebsiteDto.bureauCode;
 
     await this.website.save(website);
   }

--- a/libs/ingest/src/ingest.service.ts
+++ b/libs/ingest/src/ingest.service.ts
@@ -5,7 +5,6 @@ import { parse } from '@fast-csv/parse';
 import { CreateWebsiteDto } from '@app/database/websites/dto/create-website.dto';
 import { LoggerService } from '@app/logger';
 import { SubdomainRow } from './subdomain-row.interface';
-import { writeSync } from 'fs';
 
 @Injectable()
 export class IngestService {
@@ -30,7 +29,7 @@ export class IngestService {
 
   /**
    * writeToDatabase writes a CSV to the database.
-   * @param row T
+   * @param row a CreateWebsiteDto object.
    */
   async writeToDatabase(row: CreateWebsiteDto) {
     try {
@@ -79,6 +78,14 @@ export class IngestService {
       });
 
     stream.write(urls);
-    stream.end();
+    const end = new Promise((resolve) => {
+      stream.end(async () => {
+        await Promise.all(writes);
+        this.logger.debug('finished ingest of urls');
+        resolve('');
+      });
+    });
+
+    return end;
   }
 }

--- a/libs/ingest/src/ingest.service.ts
+++ b/libs/ingest/src/ingest.service.ts
@@ -4,6 +4,7 @@ import { map } from 'rxjs/operators';
 import { parse } from '@fast-csv/parse';
 import { CreateWebsiteDto } from '@app/database/websites/dto/create-website.dto';
 import { LoggerService } from '@app/logger';
+import { SubdomainRow } from './subdomain-row.interface';
 
 @Injectable()
 export class IngestService {
@@ -15,13 +16,13 @@ export class IngestService {
     this.logger.setContext(IngestService.name);
   }
 
-  private federalUrls =
-    'https://raw.githubusercontent.com/GSA/data/master/dotgov-domains/current-federal.csv';
+  private currentFederalSubdomains =
+    'https://raw.githubusercontent.com/GSA/data/master/dotgov-websites/site-scanning/current-federal-subdomains.csv';
 
   async getUrls(): Promise<string> {
     const urls = await this.httpService
-      .get(this.federalUrls)
-      .pipe(map(resp => resp.data))
+      .get(this.currentFederalSubdomains)
+      .pipe(map((resp) => resp.data))
       .toPromise();
     return urls;
   }
@@ -30,22 +31,38 @@ export class IngestService {
    * writeUrls writes target urls to the Websites table.
    */
   async writeUrls(urls: string, maxRows?: number) {
-    const stream = parse<CreateWebsiteDto, CreateWebsiteDto>({
+    const stream = parse<SubdomainRow, CreateWebsiteDto>({
       headers: [
+        'website',
+        'baseDomain',
         'url',
-        'type',
+        'branch',
         'agency',
-        'organization',
-        'city',
-        'state',
-        'securityContactEmail',
+        'agencyCode',
+        'bureau',
+        'bureauCode',
       ],
-      renameHeaders: true,
+      renameHeaders: true, // discard the existing headers to ease parsing
       maxRows: maxRows,
     })
-      .on('error', error => this.logger.error(error.message, error.stack))
+      .transform(
+        (data: SubdomainRow): CreateWebsiteDto => ({
+          ...data,
+          agencyCode: data.agencyCode ? parseInt(data.agencyCode) : null,
+          bureauCode: data.bureauCode ? parseInt(data.bureauCode) : null,
+        }),
+      )
+      .on('error', (error) => this.logger.error(error.message, error.stack))
       .on('data', async (row: CreateWebsiteDto) => {
-        await this.websiteService.create(row);
+        try {
+          await this.websiteService.create(row);
+        } catch (error) {
+          const err = error as Error;
+          this.logger.error(
+            `encountered error saving to database: ${err.message}`,
+            err.stack,
+          );
+        }
       })
       .on('end', (rowCount: number) => {
         this.logger.debug(rowCount);

--- a/libs/ingest/src/subdomain-row.interface.ts
+++ b/libs/ingest/src/subdomain-row.interface.ts
@@ -1,0 +1,10 @@
+export interface SubdomainRow {
+  website: string;
+  baseDomain: string;
+  url: string;
+  branch: string;
+  agency: string;
+  agencyCode: string;
+  bureau: string;
+  bureauCode: string;
+}

--- a/libs/snapshot/src/snapshot.service.ts
+++ b/libs/snapshot/src/snapshot.service.ts
@@ -13,7 +13,9 @@ export class SnapshotService {
     private logger: LoggerService,
     private websiteService: WebsiteService,
     private datetimeService: DatetimeService,
-  ) {}
+  ) {
+    this.logger.setContext(SnapshotService.name);
+  }
 
   /**
    * weeklySnapshot is meant to be called weekly (likely through a CRON job).

--- a/libs/solutions-scanner/src/solutions-scanner.service.ts
+++ b/libs/solutions-scanner/src/solutions-scanner.service.ts
@@ -15,7 +15,9 @@ export class SolutionsScannerService
   constructor(
     @Inject(BROWSER_TOKEN) private browser: Browser,
     private logger: LoggerService,
-  ) {}
+  ) {
+    this.logger.setContext(SolutionsScannerService.name);
+  }
 
   async scan(input: SolutionsInputDto): Promise<SolutionsResult> {
     const url = this.getHttpsUrls(input.url);
@@ -36,7 +38,7 @@ export class SolutionsScannerService
 
       // attach listeners
       const cssPages = [];
-      page.on('response', async response => {
+      page.on('response', async (response) => {
         if (response.request().resourceType() == 'stylesheet') {
           const cssPage = await response.text();
           cssPages.push(cssPage);
@@ -44,7 +46,7 @@ export class SolutionsScannerService
       });
 
       const outboundRequests: Request[] = [];
-      page.on('request', request => {
+      page.on('request', (request) => {
         outboundRequests.push(request);
       });
 

--- a/libs/storage/src/storage.service.ts
+++ b/libs/storage/src/storage.service.ts
@@ -21,6 +21,7 @@ export class StorageService {
     });
 
     this.bucket = this.configService.get<string>('s3.bucketName');
+    this.logger.setContext(StorageService.name);
   }
 
   async upload(fileName: string, body: string) {

--- a/run-ingest-cloud-gov.sh
+++ b/run-ingest-cloud-gov.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+#/ Usage: ./run-ingest-cloud-gov.sh    
+#/ Description: Runs the ingest task on Cloud.gov
+#/   --help: Display this help message
+usage() { grep '^#/' "$0" | cut -c4- ; exit 0 ; }
+expr "$*" : ".*--help" > /dev/null && usage
+
+echoerr() { printf "%s\n" "$*" >&2 ; }
+info()    { echoerr "[INFO]    $*" ; }
+warning() { echoerr "[WARNING] $*" ; }
+error()   { echoerr "[ERROR]   $*" ; }
+fatal()   { echoerr "[FATAL]   $*" ; exit 1 ; }
+
+cleanup() {
+  # Remove temporary files
+  # Restart services
+  info "... cleaned up"
+}
+
+if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
+  trap cleanup EXIT
+  # Script goes here
+  info "starting script ..."
+  cf run-task site-scanner-producer "node dist/apps/cli/main.js ingest" -k 1G -m 1G
+fi


### PR DESCRIPTION
Why: This adds the 25k target url list to the system -- this necessitated some changes to the `IngestService`. I also took the opportunity to clean up some issues with how the `IngestService` dealt with promises and with how the `ScanEngineConsumer` dealt with the message queue. As this increases the scale of the service by about 25x, I added a lot more logging to various services and event monitoring to the message queue consumer. 

A few other things to note: The 25k list has a slightly different schema, so I changed the `Website` entity schema to match. I added a convenience script for running the ingest task in Cloud.gov. 

Tags: ingest, target-url, logging, scan engine