### PR TITLE
Add Third Party Services fields.

### DIFF
--- a/entities/solutions-result.entity.ts
+++ b/entities/solutions-result.entity.ts
@@ -24,10 +24,7 @@ export class SolutionsResult {
   @Exclude({ toPlainOnly: true })
   updated: string;
 
-  @OneToOne(
-    () => Website,
-    website => website.solutionsResult,
-  )
+  @OneToOne(() => Website, (website) => website.solutionsResult)
   @JoinColumn()
   @Exclude({ toPlainOnly: true })
   website: Website;
@@ -96,7 +93,7 @@ export class SolutionsResult {
   @Column({ nullable: true })
   @Expose({ name: 'dap_parameters_final_url' })
   @Transform(
-    value => {
+    (value) => {
       if (value) {
         const urlSearchParams = new URLSearchParams(value);
         const result = {};
@@ -207,4 +204,19 @@ export class SolutionsResult {
   @Column({ nullable: true })
   @Expose({ name: 'sitemap_xml_pdf_count' })
   sitemapXmlPdfCount?: number;
+
+  @Column({ nullable: true })
+  @Expose({ name: 'third_party_service_domains' })
+  @Transform((value: string) => {
+    if (value) {
+      return value.split(',');
+    } else {
+      return null;
+    }
+  })
+  thirdPartyServiceDomains?: string;
+
+  @Column({ nullable: true })
+  @Expose({ name: 'third_party_service_count' })
+  thirdPartyServiceCount?: number;
 }

--- a/libs/solutions-scanner/src/solutions-scanner.service.spec.ts
+++ b/libs/solutions-scanner/src/solutions-scanner.service.spec.ts
@@ -144,6 +144,8 @@ describe('SolutionsScannerService', () => {
     expected.sitemapXmlFinalUrlMimeType = 'application/xml';
     expected.sitemapXmlCount = 200;
     expected.sitemapXmlPdfCount = 0;
+    expected.thirdPartyServiceDomains = '';
+    expected.thirdPartyServiceCount = 0;
 
     expected.status = ScanStatus.Completed;
 

--- a/libs/solutions-scanner/test/app.e2e-spec.ts
+++ b/libs/solutions-scanner/test/app.e2e-spec.ts
@@ -79,12 +79,18 @@ describe('SolutionsScanner (e2e)', () => {
     expected.sitemapXmlFinalUrl = 'https://18f.gsa.gov/sitemap.xml';
     expected.sitemapXmlFinalUrlLive = true;
     expected.sitemapTargetUrlRedirects = true;
-    expected.sitemapXmlFinalUrlFilesize = 95245;
     expected.sitemapXmlFinalUrlMimeType = 'application/xml';
-    expected.sitemapXmlCount = 686;
     expected.sitemapXmlPdfCount = 0;
+    expected.thirdPartyServiceCount = 3;
+    expected.thirdPartyServiceDomains =
+      'dap.digitalgov.gov,fonts.googleapis.com,www.google-analytics.com';
 
     const result = await service.scan(input);
+
+    // these values change frequently so just add them to the expected object.
+    expected.sitemapXmlFinalUrlFilesize = result.sitemapXmlFinalUrlFilesize;
+    expected.sitemapXmlCount = result.sitemapXmlCount;
+
     expect(result).toStrictEqual(expected);
   });
 });


### PR DESCRIPTION
Why: This adds the third party services fields to the `SolutionsScanner`. This basically builds on the DAP scan, which is why it's included with the SolutionsScanner for now. The basic methodology is to 1) capture any outbound requests from the website that aren't navigation requests and that aren't requests to the same domain as URL from which the requests are originating 2) dedupe and filter out any false-y requests. 

How: Update the SolutionScanner, update tests. Note: in the e2e tests I also added a few of the frequently-changing results to the expected object (which is unrelated to this work). 

Tags: third party services