### PR TITLE
Use to toLowerCase instead of toUpperCase. Fix order of interceptors.

### DIFF
--- a/apps/api/src/website/website.controller.ts
+++ b/apps/api/src/website/website.controller.ts
@@ -28,8 +28,8 @@ export class WebsiteController {
 
   @Get(':url')
   @UseInterceptors(
-    new NotFoundInterceptor('No website found for target url'),
     WebsiteSerializerInterceptor,
+    new NotFoundInterceptor('No website found for target url'),
   )
   async getResultByUrl(@Param('url') url: string) {
     const result = await this.websiteService.findByUrl(url);

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -94,13 +94,14 @@ export class WebsiteService {
   }
 
   async findByUrl(url: string): Promise<Website> {
-    const upperUrl = url.toUpperCase();
+    url = url.toLowerCase();
     const result = await this.website.findOne({
       relations: ['coreResult', 'solutionsResult'],
       where: {
-        url: upperUrl,
+        url: url,
       },
     });
+
     return result;
   }
 

--- a/libs/ingest/src/ingest.service.ts
+++ b/libs/ingest/src/ingest.service.ts
@@ -65,6 +65,7 @@ export class IngestService {
       .transform(
         (data: SubdomainRow): CreateWebsiteDto => ({
           ...data,
+          website: data.url.toLowerCase(),
           agencyCode: data.agencyCode ? parseInt(data.agencyCode) : null,
           bureauCode: data.bureauCode ? parseInt(data.bureauCode) : null,
         }),


### PR DESCRIPTION
Why: This is related to the ingest of the 25k urls in which the schema changed slightly from before. The issue is that the previous dataset had all urls in upper case. This change ensures that they're ingested as lower case and queried as lower case. The more sustainable long-term way to do this is to likely use a `createQueryBuilder` and use something like `LOWER(url) = LOWER(:url)` in the Typeorm query. But, the tradeoff is losing the expressivity of the repository pattern. Additionally, this change adjusts the order of the Interceptors so that we get a 404 when the target URL doesn't exist. 

Tags: bugfix, ingest, api