### PR TITLE
Bugfix: Don't flatten CSV arrays

### DIFF
--- a/libs/snapshot/src/snapshot.service.ts
+++ b/libs/snapshot/src/snapshot.service.ts
@@ -69,7 +69,7 @@ export class SnapshotService {
       transforms: [
         transforms.flatten({
           objects: true,
-          arrays: true,
+          arrays: false,
           separator: '_',
         }),
       ],

--- a/manifest.yml
+++ b/manifest.yml
@@ -24,7 +24,7 @@ applications:
   health-check-type: process
   env:
     CORE_SCAN_SCHEDULE: "0 0 * * *"
-    SNAPSHOT_SCHEDULE: "0 0 * * *"
+    SNAPSHOT_SCHEDULE: "0 8 * * *"
 
 
 - name: site-scanner-consumer


### PR DESCRIPTION
Why: The CSV arrays were being flattened into columns. This removes that and changes the snapshot schedule.