### PR TITLE
Add global prefix when on dev stage.

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,6 +5,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
   app.useGlobalPipes(
     new ValidationPipe({
       skipMissingProperties: true,
@@ -13,6 +14,10 @@ async function bootstrap() {
     }),
   );
   app.enableCors();
+
+  if (process.env.NODE_ENV === 'dev') {
+    app.setGlobalPrefix('/technology/site-scanning/v1');
+  }
 
   const options = new DocumentBuilder()
     .setTitle('Site Scanning API')


### PR DESCRIPTION
Why: In order to get Swagger requests to work, add a prefix for the dev stage. 

Tags: Swagger, open api