### PR TITLE
Add log levels and change memory and instance number.

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,7 +4,12 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, {
+    logger:
+      process.env.NODE_ENV === 'dev'
+        ? ['log', 'error', 'warn', 'debug', 'verbose']
+        : ['error', 'warn'],
+  });
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/apps/producer/src/main.ts
+++ b/apps/producer/src/main.ts
@@ -3,7 +3,12 @@ import { ProducerModule } from './producer.module';
 import { TaskService } from './task/task.service';
 
 async function bootstrap() {
-  const app = await NestFactory.createApplicationContext(ProducerModule);
+  const app = await NestFactory.createApplicationContext(ProducerModule, {
+    logger:
+      process.env.NODE_ENV === 'dev'
+        ? ['log', 'error', 'warn', 'debug', 'verbose']
+        : ['error', 'warn'],
+  });
   const taskService = app.get(TaskService);
 
   await taskService.start();

--- a/apps/scan-engine/src/main.ts
+++ b/apps/scan-engine/src/main.ts
@@ -2,7 +2,12 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.createApplicationContext(AppModule);
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger:
+      process.env.NODE_ENV === 'dev'
+        ? ['log', 'error', 'warn', 'debug', 'verbose']
+        : ['error', 'warn'],
+  });
   app.init();
 }
 bootstrap();

--- a/apps/scan-engine/src/scan-engine.consumer.ts
+++ b/apps/scan-engine/src/scan-engine.consumer.ts
@@ -52,7 +52,7 @@ export class ScanEngineConsumer {
    */
   @Process({
     name: CORE_SCAN_JOB_NAME,
-    concurrency: 6,
+    concurrency: 3,
   })
   async processCore(job: Job<CoreInputDto>) {
     this.logger.debug(`scanning ${job.data.url}`);

--- a/manifest.yml
+++ b/manifest.yml
@@ -36,7 +36,9 @@ applications:
   buildpacks:
     - https://github.com/cloudfoundry/apt-buildpack/
     - https://github.com/cloudfoundry/nodejs-buildpack/
-  instances: 3
+  instances: 4
   no-route: true
   command: npm run start:prod:scan-engine
   health-check-type: process
+  env:
+    OPTIMIZE_MEMORY: true


### PR DESCRIPTION
Why: Add log levels for `dev` and non-`dev`. Turn on `OPTIMIZE_MEMORY` environment variable. Lower concurrency number and up instance number.

Tags: logging, memory, cloud.gov