### PR TITLE
Change sort order.

### DIFF
--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -83,7 +83,7 @@ export class WebsiteService {
       });
     }
 
-    query.orderBy('website.url', 'DESC');
+    query.orderBy('website.url');
 
     return await paginate(query, options);
   }


### PR DESCRIPTION
Why: Change the API sort order to be alphabetical.

Tags: API, sort 