### PR TITLE
Add method for website data only.

### DIFF
--- a/apps/producer/src/task/task.service.spec.ts
+++ b/apps/producer/src/task/task.service.spec.ts
@@ -4,7 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CoreInputDto } from '@app/core-scanner/core.input.dto';
-import { mock, mockReset, MockProxy } from 'jest-mock-extended';
+import { mock, MockProxy } from 'jest-mock-extended';
 import { ProducerService } from '../producer/producer.service';
 import { TaskService } from './task.service';
 import { Website } from 'entities/website.entity';
@@ -63,7 +63,7 @@ describe('TaskService', () => {
     const website = new Website();
     website.id = 1;
     website.url = 'https://18f.gov';
-    websiteServiceMock.findAll
+    websiteServiceMock.findAllWebsites
       .calledWith()
       .mockResolvedValue(Promise.resolve([website]));
     const expected: CoreInputDto = {

--- a/apps/producer/src/task/task.service.ts
+++ b/apps/producer/src/task/task.service.ts
@@ -53,7 +53,7 @@ export class TaskService {
     this.logger.log('starting the Scan Engine Producer...');
 
     try {
-      const websites = await this.websiteService.findAll();
+      const websites = await this.websiteService.findAllWebsites();
 
       for (const website of websites) {
         const coreInput: CoreInputDto = {

--- a/libs/database/src/websites/websites.service.spec.ts
+++ b/libs/database/src/websites/websites.service.spec.ts
@@ -39,7 +39,7 @@ describe('WebsiteService', () => {
     mockQB.getMany.mockResolvedValue([website]);
     mockRepository.createQueryBuilder.mockReturnValue(mockQB);
 
-    const result = await service.findAll();
+    const result = await service.findWebsiteResults();
 
     const expected = [website];
     expect(result).toStrictEqual(expected);

--- a/libs/database/src/websites/websites.service.ts
+++ b/libs/database/src/websites/websites.service.ts
@@ -16,7 +16,7 @@ export class WebsiteService {
     @InjectRepository(Website) private website: Repository<Website>,
   ) {}
 
-  async findAll(): Promise<Website[]> {
+  async findWebsiteResults(): Promise<Website[]> {
     const websites = this.website
       .createQueryBuilder('website')
       .leftJoinAndSelect('website.coreResult', 'coreResult')
@@ -24,6 +24,11 @@ export class WebsiteService {
       .getMany();
 
     return websites;
+  }
+
+  async findAllWebsites(): Promise<Website[]> {
+    const result = await this.website.find();
+    return result;
   }
 
   async paginatedFilter(

--- a/libs/snapshot/src/snapshot.service.spec.ts
+++ b/libs/snapshot/src/snapshot.service.spec.ts
@@ -73,7 +73,7 @@ describe('SnapshotService', () => {
     const fileName = 'weekly-snapshot.json';
     const body = JSON.stringify([website.serialized()]);
 
-    mockWebsiteService.findAll.mockResolvedValue([website]);
+    mockWebsiteService.findWebsiteResults.mockResolvedValue([website]);
     await service.weeklySnapshot();
 
     copyDate.setDate(copyDate.getDate() - 7);

--- a/libs/snapshot/src/snapshot.service.ts
+++ b/libs/snapshot/src/snapshot.service.ts
@@ -49,7 +49,7 @@ export class SnapshotService {
 
   private async getResults(): Promise<Website[]> {
     this.logger.debug('finding all results...');
-    const results = await this.websiteService.findAll();
+    const results = await this.websiteService.findWebsiteResults();
     return results;
   }
 


### PR DESCRIPTION
Why: This adds a method to the `WebsiteService` that returns website data alone, rather than with the join results. 

Tags: WebsiteService