### PR TITLE
Return null if there aren't any robots.txt sitemaps.

### DIFF
--- a/entities/solutions-result.entity.ts
+++ b/entities/solutions-result.entity.ts
@@ -165,6 +165,8 @@ export class SolutionsResult {
   @Transform((value: string) => {
     if (value) {
       return value.split(',');
+    } else {
+      return null;
     }
   })
   robotsTxtSitemapLocations?: string;


### PR DESCRIPTION
Why: This returns `null` if there aren't any robots.txt sitemap locations. 

Closes https://github.com/18F/site-scanning/issues/844