### PR TITLE
Set snapshot to Sunday

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -24,7 +24,7 @@ applications:
   health-check-type: process
   env:
     CORE_SCAN_SCHEDULE: "0 0 * * *"
-    SNAPSHOT_SCHEDULE: "0 8 * * *"
+    SNAPSHOT_SCHEDULE: "0 8 * * Sun"
 
 
 - name: site-scanner-consumer


### PR DESCRIPTION
Why: This set the snapshot job to run weekly on Sunday. 

Tags: Snapshot, cron